### PR TITLE
Fixed screen freezing after open non cached images

### DIFF
--- a/Sources/View/Channel/FileViewer/SBUFileViewer.swift
+++ b/Sources/View/Channel/FileViewer/SBUFileViewer.swift
@@ -186,9 +186,11 @@ class SBUFileViewer: SBUBaseViewController, UIScrollViewDelegate {
         guard let urlString = urlString else { return }
         self.imageView.loadImage(urlString: urlString)
         
-        if let url = URL(string: urlString), let fileMessage = fileMessage {
-            SBUCacheManager.saveAndLoadFileToLocal(url: url, fileName: fileMessage.name)
-        }
+        // This code synchronously calls NSData(contentsOf: URL) causing the UI to hang until this method is executed.
+        // Also, this method is not necessary, because UIImageView.loadImage() caches the loaded image
+//        if let url = URL(string: urlString), let fileMessage = fileMessage {
+//            SBUCacheManager.saveAndLoadFileToLocal(url: url, fileName: fileMessage.name)
+//        }
     }
     
     open override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
After v2.1.9 SDK started freezes app after open file message first time.
This is due to the use of a synchronous thread in the viewDidLoad method, which is a movetón
https://user-images.githubusercontent.com/1070269/140511483-dbdebde2-7fd8-46d4-86fe-50a0f34f6687.mov

