### PR TITLE
Ask for arm64 support

### DIFF
--- a/SendBirdUIKit.podspec
+++ b/SendBirdUIKit.podspec
@@ -17,6 +17,4 @@ Pod::Spec.new do |s|
 	s.requires_arc = true
 	s.dependency "SendBirdSDK", "~>3.0.226"
 	s.ios.library = "icucore"
-	s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-	s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
This PR is open to ask direct support on the library.

SendBirdUIKit miss the support of arm64 binary on simulator, while SendBirdSDK supports it correctly.
Would there be chance to have a fix of the SoundBirdUIKit.xcframework containing arm64 also for the simulator?

We would like to upgrade the project and move everything under M1 Apple Silicon.

Thank you in advance.