### PR TITLE
Fix: includeEmptyChannel fix with customizedChannelListQuery

### DIFF
--- a/Sources/View/ChannelList/SBUChannelListViewController.swift
+++ b/Sources/View/ChannelList/SBUChannelListViewController.swift
@@ -465,7 +465,8 @@ open class SBUChannelListViewController: SBUBaseChannelListViewController {
     public func upsertChannels(_ channels: [SBDGroupChannel]?, needReload: Bool) {
         guard let channels = channels else { return }
         
-        let includeEmptyChannel = self.channelListViewModel?.channelListQuery?.includeEmptyChannel ?? false
+        let includeCustomizedEmptyChannel = self.customizedChannelListQuery?.includeEmptyChannel ?? false
+        let includeEmptyChannel = self.channelListViewModel?.channelListQuery?.includeEmptyChannel ?? includeCustomizedEmptyChannel
         for channel in channels {
             guard (channel.lastMessage != nil || includeEmptyChannel) else { continue }
             guard let index = self.channelList.firstIndex(where: { $0.channelUrl == channel.channelUrl }) else {


### PR DESCRIPTION
I found a use case when includeEmptyChannel doesn't work as expected.

If you init ChannelListViewController using a custom query self.init(channelListQuery: query) even if your query explicitly request for emptyChannelList the app doesn't include that in the tableview.



