### PR TITLE
Range check channelList in didSelectRowAt

### DIFF
--- a/Sources/View/ChannelList/SBUGroupChannelListViewController.swift
+++ b/Sources/View/ChannelList/SBUGroupChannelListViewController.swift
@@ -281,7 +281,8 @@ open class SBUGroupChannelListViewController: SBUBaseChannelListViewController, 
     // MARK: - SBUGroupChannelListModuleListDelegate
     open func channelListModule(_ listComponent: SBUGroupChannelListModule.List,
                                 didSelectRowAt indexPath: IndexPath) {
-        guard let channel = self.viewModel?.channelList[indexPath.row] else { return }
+        guard indexPath.row < self.channelList.count, 
+              let channel = self.viewModel?.channelList[indexPath.row] else { return }
         self.showChannel(channelUrl: channel.channelUrl)
     }
     


### PR DESCRIPTION
(Hi, I know you don't accept contributions but I was hoping this would be a quick way to show this one small issue)

I've been getting an occasional out of bounds crash when selecting a channel in `SBUGroupChannelListViewController`. I think the underlying channelList is being reloaded while I tap, resulting in the subscript being out of bounds. 

I think it's necessary to check the range prior to using the subscript `channelList[indexPath.row]` (even though it's in a guard statement already, which does not protect against out of bounds subscripts)

Thank you for making SendbirdUIKit, it's really great!