### PR TITLE
Release/3.31.0 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+### v3.31.0 (Jun 20, 2025)
+
+# SendbirdUIKit
+### Improvements and Deprecations
+We have fixed autolayout warnings. 
+In the process, we have improved message cell types to be registered based on Metatypes, instead of instances. 
+Accordingly, the below interfaces in `SBUGroupChannelModule.List` have been deprecated. 
+- `open func register(adminMessageCell:nib:)`
+- `open func register(userMessageCell:nib:)` 
+- `open func register(fileMessageCell:nib:)` 
+- `open func register(multipleFilesMessageCell:nib:)` 
+- `open func register(typingIndicatorMessageCell:nib:)` 
+- `open func register(unknownMessageCell:nib:)`   
+- `open func register(customMessageCell:nib:)`     
+
+# SendbirdUIMessageTemplate
+- none
+
 ### v3.30.2 (May 19, 2025)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -25,13 +25,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.30.2/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "e293b07b0b695f0848f3d45ec83eff5687fcfdc48d58e6f9715b86d4e3bc2984" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "64726c2b7b655671adeb15229c9d3fa4b8b1263d5d4fdbbf86bfa1039427ac30" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.30.2/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "f218902a6b1fbc40127b24dc3c8156da4829079e90d6c939f6ac1643f4fe968f" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "c5943e894d0d5bfc15485614a929d6e630fe3b2f830ea6efe99468d66688c41e" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",

--- a/Sample/QuickStart.xcodeproj/project.pbxproj
+++ b/Sample/QuickStart.xcodeproj/project.pbxproj
@@ -3845,7 +3845,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.30.2;
+				MARKETING_VERSION = 3.31.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -3873,7 +3873,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.30.2;
+				MARKETING_VERSION = 3.31.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4018,7 +4018,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.30.2;
+				MARKETING_VERSION = 3.31.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4046,7 +4046,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.30.2;
+				MARKETING_VERSION = 3.31.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4095,7 +4095,7 @@
 			repositoryURL = "https://github.com/sendbird/sendbird-uikit-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.30.2;
+				minimumVersion = 3.31.0;
 			};
 		};
 		A4CD81EE92C875D0E22463C6 /* XCRemoteSwiftPackageReference "sendbird-chat-sdk-ios" */ = {

--- a/Sample/project.yml
+++ b/Sample/project.yml
@@ -11,7 +11,7 @@ packages:
     from: 4.26.0
   SendbirdUIKit:
     url: https://github.com/sendbird/sendbird-uikit-ios-spm
-    from: 3.30.2
+    from: 3.31.0
 schemes:
   QuickStart:
     analyze:
@@ -38,7 +38,7 @@ settingGroups:
     FRAMEWORK_SEARCH_PATHS: ''
     IPHONEOS_DEPLOYMENT_TARGET: '13.0'
     LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
-    MARKETING_VERSION: '3.30.2'
+    MARKETING_VERSION: '3.31.0'
     PRODUCT_NAME: "$(TARGET_NAME)"
     SDKROOT: iphoneos
     SWIFT_VERSION: '5.0'

--- a/SendBirdUIKit.podspec
+++ b/SendBirdUIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "SendBirdUIKit"
-	s.version = "3.30.2"
+	s.version = "3.31.0"
 	s.summary = "UIKit based on SendbirdChatSDK"
 	s.description = "Sendbird UIKit is a framework composed of basic UI components based on SendbirdChatSDK."
 	s.homepage = "https://sendbird.com"
@@ -16,11 +16,11 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "208946e42c9dc9509edaf4ed66878a6f5fed5c62" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "4688c0586a0d4ae38a4d403b654ef4d6d4eac0a8" }
 	s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true
 	s.dependency "SendbirdChatSDK", ">= 4.26.0"
-	s.dependency "SendbirdUIMessageTemplate", ">= 3.30.2"
+	s.dependency "SendbirdUIMessageTemplate", ">= 3.31.0"
 	s.ios.library = "icucore"
 end

--- a/SendbirdUIMessageTemplate.podspec
+++ b/SendbirdUIMessageTemplate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "SendbirdUIMessageTemplate"
-	s.version = "3.30.2"
+	s.version = "3.31.0"
 	s.summary = "SendbirdUIMessageTemplate based on SendbirdChatSDK"
 	s.description = "Sendbird UI MessageTemplate is a framework composed of basic Message Template UI components based on SendbirdChatSDK."
 	s.homepage = "https://sendbird.com"
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "2f24d0ff10df25aaa9e2a51850b8e8766a2cd305" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "c5192bb94a818c386947fc2937fddf2d33a95021" }
 	s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true

--- a/Sources/Module/Channel/GroupChannel/SBUGroupChannelModule.List.swift
+++ b/Sources/Module/Channel/GroupChannel/SBUGroupChannelModule.List.swift
@@ -165,7 +165,7 @@ extension SBUGroupChannelModule {
     open class List: SBUBaseChannelModule.List, SBUVoicePlayerDelegate {
 
         // MARK: - UI properties (Public)
-         
+        
         /// The message cell for `AdminMessage` object. Use `register(adminMessageCell:nib:)` to update.
         public private(set) var adminMessageCell: SBUBaseMessageCell?
         
@@ -291,32 +291,40 @@ extension SBUGroupChannelModule {
             
             super.setupViews()
             
-            // register cell (GroupChannel)
+            // Register message cell types
             if self.adminMessageCell == nil {
-                self.register(adminMessageCell: Self.AdminMessageCell.init())
-            }
-            if self.userMessageCell == nil {
-                self.register(userMessageCell: Self.UserMessageCell.init())
-            }
-            if self.fileMessageCell == nil {
-                self.register(fileMessageCell: Self.FileMessageCell.init())
-            }
-            if self.multipleFilesMessageCell == nil {
-                self.register(multipleFilesMessageCell: Self.MultipleFilesMessageCell.init())
-            }
-            if self.typingIndicatorMessageCell == nil {
-                self.register(typingIndicatorMessageCell: Self.TypingIndicatorMessageCell.init())
-            }
-            if self.unknownMessageCell == nil {
-                self.register(unknownMessageCell: Self.UnknownMessageCell.init())
-            }
-            if self.messageTemplateCell == nil {
-                self.register(messageTemplateCell: SBUMessageTemplateCell())
-            }
-            if let cellType = Self.CustomMessageCell {
-                self.register(customMessageCell: cellType.init())
+                self.register(messageCellType: Self.AdminMessageCell)
             }
             
+            if self.userMessageCell == nil {
+                self.register(messageCellType: Self.UserMessageCell)
+            }
+            
+            if self.fileMessageCell == nil {
+                self.register(messageCellType: Self.FileMessageCell)
+            }
+            
+            if self.multipleFilesMessageCell == nil {
+                self.register(messageCellType: Self.MultipleFilesMessageCell)
+            }
+            
+            if self.typingIndicatorMessageCell == nil {
+                self.register(messageCellType: Self.TypingIndicatorMessageCell)
+            }
+            
+            if self.unknownMessageCell == nil {
+                self.register(messageCellType: Self.UnknownMessageCell)
+            }
+            
+            if self.messageTemplateCell == nil {
+                self.register(messageCellType: SBUMessageTemplateCell.self)
+            }
+            
+            if let customMessageCellType = Self.CustomMessageCell {
+                self.register(messageCellType: customMessageCellType)
+            }
+            
+            // Add subviews
             if let newMessageInfoView = self.newMessageInfoView {
                 newMessageInfoView.isHidden = true
                 self.addSubview(newMessageInfoView)
@@ -480,6 +488,12 @@ extension SBUGroupChannelModule {
         
         // MARK: - TableView: Cell
         
+        /// Registers message cell type to the message tableview.
+        /// - Since: 3.31.0
+        public func register(messageCellType: SBUBaseMessageCell.Type) {
+            self.tableView.register(messageCellType, forCellReuseIdentifier: messageCellType.sbu_className)
+        }
+        
         /// Registers a custom cell as a admin message cell based on `SBUBaseMessageCell`.
         /// - Parameters:
         ///   - adminMessageCell: Customized admin message cell
@@ -489,9 +503,13 @@ extension SBUGroupChannelModule {
         /// listComponent.register(adminMessageCell: MyAdminMessageCell)
         /// listComponent.configure(delegate: self, dataSource: self, theme: theme)
         /// ```
+        @available(*, deprecated, message: "This method is deprecated in 3.31.0. Use `SBUGroupChannelModule.List.AdminMessageCell` instead")
         open func register(adminMessageCell: SBUBaseMessageCell, nib: UINib? = nil) {
             self.adminMessageCell = adminMessageCell
-            self.register(messageCell: adminMessageCell, nib: nib)
+            
+            Self.AdminMessageCell = type(of: adminMessageCell)
+            self.register(nib: nib, messageCell: adminMessageCell)
+            self.register(messageCellType: type(of: adminMessageCell))
         }
         
         /// Registers a custom cell as a user message cell based on `SBUBaseMessageCell`.
@@ -503,9 +521,13 @@ extension SBUGroupChannelModule {
         /// listComponent.register(userMessageCell: MyUserMessageCell)
         /// listComponent.configure(delegate: self, dataSource: self, theme: theme)
         /// ```
+        @available(*, deprecated, message: "This method is deprecated in 3.31.0. Use `SBUGroupChannelModule.List.UserMessageCell` instead")
         open func register(userMessageCell: SBUBaseMessageCell, nib: UINib? = nil) {
             self.userMessageCell = userMessageCell
-            self.register(messageCell: userMessageCell, nib: nib)
+
+            Self.UserMessageCell = type(of: userMessageCell)
+            self.register(nib: nib, messageCell: userMessageCell)
+            self.register(messageCellType: type(of: userMessageCell))
         }
         
         /// Registers a custom cell as a file message cell based on `SBUBaseMessageCell`.
@@ -517,9 +539,13 @@ extension SBUGroupChannelModule {
         /// listComponent.register(fileMessageCell: MyFileMessageCell)
         /// listComponent.configure(delegate: self, dataSource: self, theme: theme)
         /// ```
+        @available(*, deprecated, message: "This method is deprecated in 3.31.0. Use `SBUGroupChannelModule.List.FileMessageCell` instead")
         open func register(fileMessageCell: SBUBaseMessageCell, nib: UINib? = nil) {
             self.fileMessageCell = fileMessageCell
-            self.register(messageCell: fileMessageCell, nib: nib)
+            
+            Self.FileMessageCell = type(of: fileMessageCell)
+            self.register(nib: nib, messageCell: fileMessageCell)
+            self.register(messageCellType: type(of: fileMessageCell))
         }
         
         /// Registers a custom cell as a multiple files message cell based on `SBUBaseMessageCell`.
@@ -532,9 +558,13 @@ extension SBUGroupChannelModule {
         /// listComponent.configure(delegate: self, dataSource: self, theme: theme)
         /// ```
         /// - Since: 3.10.0
+        @available(*, deprecated, message: "This method is deprecated in 3.31.0. Use `SBUGroupChannelModule.List.MultipleFilesMessageCell` instead")
         open func register(multipleFilesMessageCell: SBUBaseMessageCell, nib: UINib? = nil) {
             self.multipleFilesMessageCell = multipleFilesMessageCell
-            self.register(messageCell: multipleFilesMessageCell, nib: nib)
+            
+            Self.MultipleFilesMessageCell = type(of: multipleFilesMessageCell)
+            self.register(nib: nib, messageCell: multipleFilesMessageCell)
+            self.register(messageCellType: type(of: multipleFilesMessageCell))
         }
         
         /// Registers a custom cell as a typing message cell based on `SBUBaseMessageCell`.
@@ -547,9 +577,13 @@ extension SBUGroupChannelModule {
         /// listComponent.configure(delegate: self, dataSource: self, theme: theme)
         /// ```
         /// - Since: 3.12.0
+        @available(*, deprecated, message: "This method is deprecated in 3.31.0. Use `SBUGroupChannelModule.List.TypingIndicatorMessageCell` instead")
         open func register(typingIndicatorMessageCell: SBUBaseMessageCell, nib: UINib? = nil) {
             self.typingIndicatorMessageCell = typingIndicatorMessageCell
-            self.register(messageCell: typingIndicatorMessageCell, nib: nib)
+            
+            Self.TypingIndicatorMessageCell = type(of: typingIndicatorMessageCell)
+            self.register(nib: nib, messageCell: typingIndicatorMessageCell)
+            self.register(messageCellType: type(of: typingIndicatorMessageCell))
         }
         
         /// Registers a custom cell as a message template cell based on `SBUMessageTemplateCell`.
@@ -564,7 +598,9 @@ extension SBUGroupChannelModule {
         /// - Since: 3.27.2
         open func register(messageTemplateCell: SBUMessageTemplateCell, nib: UINib? = nil) {
             self.messageTemplateCell = messageTemplateCell
-            self.register(messageCell: messageTemplateCell, nib: nib)
+            
+            self.register(nib: nib, messageCell: messageTemplateCell)
+            self.register(messageCellType: type(of: messageTemplateCell))
         }
         
         /// Registers a custom cell as a unknown message cell based on `SBUBaseMessageCell`.
@@ -576,9 +612,13 @@ extension SBUGroupChannelModule {
         /// listComponent.register(unknownMessageCell: MyUnknownMessageCell)
         /// listComponent.configure(delegate: self, dataSource: self, theme: theme)
         /// ```
+        @available(*, deprecated, message: "Use `SBUGroupChannelModule.List.UnknownMessageCell` instead")
         open func register(unknownMessageCell: SBUBaseMessageCell, nib: UINib? = nil) {
             self.unknownMessageCell = unknownMessageCell
-            self.register(messageCell: unknownMessageCell, nib: nib)
+            
+            Self.UnknownMessageCell = type(of: unknownMessageCell)
+            self.register(nib: nib, messageCell: unknownMessageCell)
+            self.register(messageCellType: type(of: unknownMessageCell))
         }
         
         /// Registers a custom cell as a additional message cell based on `SBUBaseMessageCell`.
@@ -590,9 +630,13 @@ extension SBUGroupChannelModule {
         /// listComponent.register(customMessageCell: MyCustomMessageCell)
         /// listComponent.configure(delegate: self, dataSource: self, theme: theme)
         /// ```
+        @available(*, deprecated, message: "Use `SBUGroupChannelModule.List.CustomMessageCell` instead")
         open func register(customMessageCell: SBUBaseMessageCell, nib: UINib? = nil) {
             self.customMessageCell = customMessageCell
-            self.register(messageCell: customMessageCell, nib: nib)
+            
+            Self.CustomMessageCell = type(of: customMessageCell)
+            self.register(nib: nib, messageCell: customMessageCell)
+            self.register(messageCellType: type(of: customMessageCell))
         }
         
         /// Configures cell with message for a particular row.
@@ -881,6 +925,15 @@ extension SBUGroupChannelModule {
             }
         }
         
+        public func register(nib: UINib? = nil, messageCell: SBUBaseMessageCell) {
+            if let nib = nib {
+                self.tableView.register(
+                    nib,
+                    forCellReuseIdentifier: messageCell.sbu_className
+                )
+            }
+        }
+        
         /// Generates identifier of message cell.
         /// - Parameter message: Message object
         /// - Returns: The identifier of message cell.
@@ -896,17 +949,17 @@ extension SBUGroupChannelModule {
             
             switch message {
             case is SBUTypingIndicatorMessage:
-                return typingIndicatorMessageCell?.sbu_className ?? SBUTypingIndicatorMessageCell.sbu_className
+                return Self.TypingIndicatorMessageCell.sbu_className
             case is MultipleFilesMessage:
-                return multipleFilesMessageCell?.sbu_className ?? SBUMultipleFilesMessageCell.sbu_className
+                return Self.MultipleFilesMessageCell.sbu_className
             case is FileMessage:
-                return fileMessageCell?.sbu_className ?? SBUFileMessageCell.sbu_className
+                return Self.FileMessageCell.sbu_className
             case is UserMessage:
-                return userMessageCell?.sbu_className ?? SBUUserMessageCell.sbu_className
+                return Self.UserMessageCell.sbu_className
             case is AdminMessage:
-                return adminMessageCell?.sbu_className ?? SBUAdminMessageCell.sbu_className
+                return Self.AdminMessageCell.sbu_className
             default:
-                return unknownMessageCell?.sbu_className ?? SBUUnknownMessageCell.sbu_className
+                return Self.UnknownMessageCell.sbu_className
             }
         }
         

--- a/Sources/Module/MessageThread/SBUMessageThreadModule.Input.swift
+++ b/Sources/Module/MessageThread/SBUMessageThreadModule.Input.swift
@@ -718,11 +718,10 @@ extension SBUMessageThreadModule {
         /// Updates the placeholder text.
         open func updatePlaceholder() {
             let messageInputView = self.messageInputView as? SBUMessageInputView
+            messageInputView?.isThreadMessage = true
             if (self.parentMessage?.threadInfo.replyCount ?? 0) > 0 {
-                messageInputView?.isThreadMessage = true
                 messageInputView?.isThreadFirstMessage = false
             } else {
-                messageInputView?.isThreadMessage = false
                 messageInputView?.isThreadFirstMessage = true
             }
             

--- a/Sources/View/Channel/Header/SBUChannelTitleView.swift
+++ b/Sources/View/Channel/Header/SBUChannelTitleView.swift
@@ -72,7 +72,6 @@ open class SBUChannelTitleView: UIView {
         
         self.contentView.addSubview(self.stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor).isActive = true
         self.addSubview(self.contentView)
         
     }

--- a/Sources/View/Channel/MessageInput/SBUQuoteMessageInputView.swift
+++ b/Sources/View/Channel/MessageInput/SBUQuoteMessageInputView.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SendbirdChatSDK
 
-protocol SBUQuoteMessageInputViewDelegate: AnyObject {
+public protocol SBUQuoteMessageInputViewDelegate: AnyObject {
     func didTapClose()
 }
 


### PR DESCRIPTION
# SendbirdUIKit
### Improvements and Deprecations
We have fixed autolayout warnings. 
In the process, we have improved message cell types to be registered based on Metatypes, instead of instances. 
Accordingly, the below interfaces in `SBUGroupChannelModule.List` have been deprecated. 
- `open func register(adminMessageCell:nib:)`
- `open func register(userMessageCell:nib:)` 
- `open func register(fileMessageCell:nib:)` 
- `open func register(multipleFilesMessageCell:nib:)` 
- `open func register(typingIndicatorMessageCell:nib:)` 
- `open func register(unknownMessageCell:nib:)`   
- `open func register(customMessageCell:nib:)`     

# SendbirdUIMessageTemplate
- none