### PR TITLE
Release/1.0.999 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### v1.0.999 (Jul 24, 2025)
+
+# SendbirdUIKit
+### Improvements and Deprecations
+testing...     
+
+# SendbirdUIMessageTemplate
+- none
+
 ### v3.31.0 (Jun 20, 2025)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -26,12 +26,12 @@ let package = Package(
         .binaryTarget(
             name: "SendbirdUIKit",
             url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "64726c2b7b655671adeb15229c9d3fa4b8b1263d5d4fdbbf86bfa1039427ac30" // SendbirdUIKit_CHECKSUM
+            checksum: "a7c260cc109e6d31cae1d6555ea6ac3c8ddfe2a5a5d3e75f390cb9598bac23d1" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
             url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "c5943e894d0d5bfc15485614a929d6e630fe3b2f830ea6efe99468d66688c41e" // SendbirdUIMessageTemplate_CHECKSUM
+            checksum: "752eed2501a9807856159834fdb948011a1098c649e0582796513165c3a9cd71" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",

--- a/Sample/QuickStart.xcodeproj/project.pbxproj
+++ b/Sample/QuickStart.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -3222,7 +3222,7 @@
 				A4CD81EE92C875D0E22463C6 /* XCRemoteSwiftPackageReference "sendbird-chat-sdk-ios" */,
 				4935A9393C043AF555B43E51 /* XCRemoteSwiftPackageReference "sendbird-uikit-ios-spm" */,
 			);
-			preferredProjectObjectVersion = 54;
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/SendBirdUIKit.podspec
+++ b/SendBirdUIKit.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "4688c0586a0d4ae38a4d403b654ef4d6d4eac0a8" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "50efc85b797ac171dacd2a0e88ac2de84c30de0f" }
 	s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true

--- a/SendbirdUIMessageTemplate.podspec
+++ b/SendbirdUIMessageTemplate.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "c5192bb94a818c386947fc2937fddf2d33a95021" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "ec499384b4fe2b0cc76c369db35fac85d86876dc" }
 	s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true

--- a/Sources/View/Channel/MessageInput/SBUMessageInputView.swift
+++ b/Sources/View/Channel/MessageInput/SBUMessageInputView.swift
@@ -303,7 +303,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     }()
     
     /// Stack view that takes up any view that go on top of the textfield.
-    /// - Since: [SWIFTUI_NEXT_VERSION]
+    /// - Since: 1.1.0 (SendbirdSwiftUI)
     lazy var topStackView: SBUStackView = {
         return SBUStackView(axis: .vertical, alignment: .fill, spacing: 0)
     }()
@@ -431,7 +431,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         self.datasource?.channelForMessageInputView(self)?.channelType ?? .group
     }
     
-    /// - Since: [SWIFTUI_NEXT_VERSION]
+    /// - Since: 1.1.0 (SendbirdSwiftUI)
     var isQuoteReplyingMode = false
     
     // MARK: - Life cycle


### PR DESCRIPTION
# SendbirdUIKit
### Improvements and Deprecations
We have fixed autolayout warnings. 
In the process, we have improved message cell types to be registered based on Metatypes, instead of instances. 
Accordingly, the below interfaces in `SBUGroupChannelModule.List` have been deprecated. 
- `open func register(adminMessageCell:nib:)`
- `open func register(userMessageCell:nib:)` 
- `open func register(fileMessageCell:nib:)` 
- `open func register(multipleFilesMessageCell:nib:)` 
- `open func register(typingIndicatorMessageCell:nib:)` 
- `open func register(unknownMessageCell:nib:)`   
- `open func register(customMessageCell:nib:)`     

# SendbirdUIMessageTemplate
- none