### PR TITLE
Release/1.0.999 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### v1.0.999 (Jul 24, 2025)
+
+# SendbirdUIKit
+### Improvements and Deprecations
+testing...     
+
+# SendbirdUIMessageTemplate
+- none
+
 ### v3.31.0 (Jun 20, 2025)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -25,13 +25,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "64726c2b7b655671adeb15229c9d3fa4b8b1263d5d4fdbbf86bfa1039427ac30" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/1.0.999/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "cb526ef087b255ce299de454490ebb4be45af25983fe5566bff9272b35d010ee" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "c5943e894d0d5bfc15485614a929d6e630fe3b2f830ea6efe99468d66688c41e" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/1.0.999/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "2fee4293fbc3a9832fdf9b9f439dd39d5443cafdbc35396e9be299cacd32db4c" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",

--- a/Sample/QuickStart.xcodeproj/project.pbxproj
+++ b/Sample/QuickStart.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -3222,7 +3222,7 @@
 				A4CD81EE92C875D0E22463C6 /* XCRemoteSwiftPackageReference "sendbird-chat-sdk-ios" */,
 				4935A9393C043AF555B43E51 /* XCRemoteSwiftPackageReference "sendbird-uikit-ios-spm" */,
 			);
-			preferredProjectObjectVersion = 54;
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -3845,7 +3845,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.0;
+				MARKETING_VERSION = 1.0.999;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -3873,7 +3873,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.0;
+				MARKETING_VERSION = 1.0.999;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4018,7 +4018,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.0;
+				MARKETING_VERSION = 1.0.999;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4046,7 +4046,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.0;
+				MARKETING_VERSION = 1.0.999;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4095,7 +4095,7 @@
 			repositoryURL = "https://github.com/sendbird/sendbird-uikit-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.31.0;
+				minimumVersion = 1.0.999;
 			};
 		};
 		A4CD81EE92C875D0E22463C6 /* XCRemoteSwiftPackageReference "sendbird-chat-sdk-ios" */ = {

--- a/Sample/project.yml
+++ b/Sample/project.yml
@@ -11,7 +11,7 @@ packages:
     from: 4.26.0
   SendbirdUIKit:
     url: https://github.com/sendbird/sendbird-uikit-ios-spm
-    from: 3.31.0
+    from: 1.0.999
 schemes:
   QuickStart:
     analyze:
@@ -38,7 +38,7 @@ settingGroups:
     FRAMEWORK_SEARCH_PATHS: ''
     IPHONEOS_DEPLOYMENT_TARGET: '13.0'
     LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
-    MARKETING_VERSION: '3.31.0'
+    MARKETING_VERSION: '1.0.999'
     PRODUCT_NAME: "$(TARGET_NAME)"
     SDKROOT: iphoneos
     SWIFT_VERSION: '5.0'

--- a/SendBirdUIKit.podspec
+++ b/SendBirdUIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "SendBirdUIKit"
-	s.version = "3.31.0"
+	s.version = "1.0.999"
 	s.summary = "UIKit based on SendbirdChatSDK"
 	s.description = "Sendbird UIKit is a framework composed of basic UI components based on SendbirdChatSDK."
 	s.homepage = "https://sendbird.com"
@@ -16,11 +16,11 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "4688c0586a0d4ae38a4d403b654ef4d6d4eac0a8" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "6aad619d750a373afcd132e2af2f4e7829c91eab" }
 	s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true
 	s.dependency "SendbirdChatSDK", ">= 4.26.0"
-	s.dependency "SendbirdUIMessageTemplate", ">= 3.31.0"
+	s.dependency "SendbirdUIMessageTemplate", ">= 1.0.999"
 	s.ios.library = "icucore"
 end

--- a/SendbirdUIMessageTemplate.podspec
+++ b/SendbirdUIMessageTemplate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "SendbirdUIMessageTemplate"
-	s.version = "3.31.0"
+	s.version = "1.0.999"
 	s.summary = "SendbirdUIMessageTemplate based on SendbirdChatSDK"
 	s.description = "Sendbird UI MessageTemplate is a framework composed of basic Message Template UI components based on SendbirdChatSDK."
 	s.homepage = "https://sendbird.com"
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "c5192bb94a818c386947fc2937fddf2d33a95021" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "96b140fb9e38b65f03464de730142558f231e46c" }
 	s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true

--- a/Sources/View/Channel/MessageInput/SBUMessageInputView.swift
+++ b/Sources/View/Channel/MessageInput/SBUMessageInputView.swift
@@ -303,7 +303,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     }()
     
     /// Stack view that takes up any view that go on top of the textfield.
-    /// - Since: [SWIFTUI_NEXT_VERSION]
+    /// - Since: 1.1.0 (SendbirdSwiftUI)
     lazy var topStackView: SBUStackView = {
         return SBUStackView(axis: .vertical, alignment: .fill, spacing: 0)
     }()
@@ -431,7 +431,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         self.datasource?.channelForMessageInputView(self)?.channelType ?? .group
     }
     
-    /// - Since: [SWIFTUI_NEXT_VERSION]
+    /// - Since: 1.1.0 (SendbirdSwiftUI)
     var isQuoteReplyingMode = false
     
     // MARK: - Life cycle


### PR DESCRIPTION
# SendbirdUIKit
### Improvements and Deprecations
We have fixed autolayout warnings. 
In the process, we have improved message cell types to be registered based on Metatypes, instead of instances. 
Accordingly, the below interfaces in `SBUGroupChannelModule.List` have been deprecated. 
- `open func register(adminMessageCell:nib:)`
- `open func register(userMessageCell:nib:)` 
- `open func register(fileMessageCell:nib:)` 
- `open func register(multipleFilesMessageCell:nib:)` 
- `open func register(typingIndicatorMessageCell:nib:)` 
- `open func register(unknownMessageCell:nib:)`   
- `open func register(customMessageCell:nib:)`     

# SendbirdUIMessageTemplate
- none