### PR TITLE
Release/3.31.1 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### v3.31.1 (Jul 25, 2025)
+
+# SendbirdUIKit
+
+## Improvements
+
+- Updated the SDK build base to Xcode 16.1.
+
+# SendbirdUIMessageTemplate
+
+## Improvements
+
+- Updated the SDK build base to Xcode 16.1.
+
 ### v3.31.0 (Jun 20, 2025)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -19,19 +19,19 @@ let package = Package(
         .package(
             name: "SendbirdChatSDK",
             url: "https://github.com/sendbird/sendbird-chat-sdk-ios",
-            from: "4.26.0"
+            from: "4.29.0"
         ),
     ],
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "64726c2b7b655671adeb15229c9d3fa4b8b1263d5d4fdbbf86bfa1039427ac30" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.1/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "76f1c50d7e1d0503c9a71ae761cadddaf454398d149e322e5a5a9802dbd7c54f" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "c5943e894d0d5bfc15485614a929d6e630fe3b2f830ea6efe99468d66688c41e" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.1/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "e9b79ce17dae84da74e7d1f359515f7d3f14f6507d95be281f3631f89013c5ef" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The minimum requirements for Sendbird UIKit for iOS are:
 
 - iOS 13+
 - Swift 5.10+
-- Sendbird Chat SDK for iOS 4.26.0+
+- Sendbird Chat SDK for iOS 4.29.0+
 
 <br />
 

--- a/Sample/QuickStart.xcodeproj/project.pbxproj
+++ b/Sample/QuickStart.xcodeproj/project.pbxproj
@@ -3845,7 +3845,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.0;
+				MARKETING_VERSION = 3.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -3873,7 +3873,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.0;
+				MARKETING_VERSION = 3.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4018,7 +4018,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.0;
+				MARKETING_VERSION = 3.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4046,7 +4046,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.0;
+				MARKETING_VERSION = 3.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4095,7 +4095,7 @@
 			repositoryURL = "https://github.com/sendbird/sendbird-uikit-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.31.0;
+				minimumVersion = 3.31.1;
 			};
 		};
 		A4CD81EE92C875D0E22463C6 /* XCRemoteSwiftPackageReference "sendbird-chat-sdk-ios" */ = {
@@ -4103,7 +4103,7 @@
 			repositoryURL = "https://github.com/sendbird/sendbird-chat-sdk-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.26.0;
+				minimumVersion = 4.29.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Sample/project.yml
+++ b/Sample/project.yml
@@ -8,10 +8,10 @@ options:
 packages: 
   SendbirdChatSDK: 
     url: https://github.com/sendbird/sendbird-chat-sdk-ios
-    from: 4.26.0
+    from: 4.29.0
   SendbirdUIKit:
     url: https://github.com/sendbird/sendbird-uikit-ios-spm
-    from: 3.31.0
+    from: 3.31.1
 schemes:
   QuickStart:
     analyze:
@@ -38,7 +38,7 @@ settingGroups:
     FRAMEWORK_SEARCH_PATHS: ''
     IPHONEOS_DEPLOYMENT_TARGET: '13.0'
     LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
-    MARKETING_VERSION: '3.31.0'
+    MARKETING_VERSION: '3.31.1'
     PRODUCT_NAME: "$(TARGET_NAME)"
     SDKROOT: iphoneos
     SWIFT_VERSION: '5.0'

--- a/SendBirdUIKit.podspec
+++ b/SendBirdUIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "SendBirdUIKit"
-	s.version = "3.31.0"
+	s.version = "3.31.1"
 	s.summary = "UIKit based on SendbirdChatSDK"
 	s.description = "Sendbird UIKit is a framework composed of basic UI components based on SendbirdChatSDK."
 	s.homepage = "https://sendbird.com"
@@ -16,11 +16,11 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "4688c0586a0d4ae38a4d403b654ef4d6d4eac0a8" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "538ee7aa07734f207815fdaab817b6d73763cb32" }
 	s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true
-	s.dependency "SendbirdChatSDK", ">= 4.26.0"
-	s.dependency "SendbirdUIMessageTemplate", ">= 3.31.0"
+	s.dependency "SendbirdChatSDK", ">= 4.29.0"
+	s.dependency "SendbirdUIMessageTemplate", ">= 3.31.1"
 	s.ios.library = "icucore"
 end

--- a/SendbirdUIMessageTemplate.podspec
+++ b/SendbirdUIMessageTemplate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "SendbirdUIMessageTemplate"
-	s.version = "3.31.0"
+	s.version = "3.31.1"
 	s.summary = "SendbirdUIMessageTemplate based on SendbirdChatSDK"
 	s.description = "Sendbird UI MessageTemplate is a framework composed of basic Message Template UI components based on SendbirdChatSDK."
 	s.homepage = "https://sendbird.com"
@@ -15,10 +15,10 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "c5192bb94a818c386947fc2937fddf2d33a95021" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "a61ca0bac660e0a54e3cab5093cfd24e8cc3d2f0" }
 	s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true
-	s.dependency "SendbirdChatSDK", ">= 4.26.0"
+	s.dependency "SendbirdChatSDK", ">= 4.29.0"
 	s.ios.library = "icucore"
 end

--- a/Sources/View/Channel/MessageInput/SBUMessageInputView.swift
+++ b/Sources/View/Channel/MessageInput/SBUMessageInputView.swift
@@ -303,7 +303,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     }()
     
     /// Stack view that takes up any view that go on top of the textfield.
-    /// - Since: [SWIFTUI_NEXT_VERSION]
+    /// - Since: 1.1.0 (SendbirdSwiftUI)
     lazy var topStackView: SBUStackView = {
         return SBUStackView(axis: .vertical, alignment: .fill, spacing: 0)
     }()
@@ -431,7 +431,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         self.datasource?.channelForMessageInputView(self)?.channelType ?? .group
     }
     
-    /// - Since: [SWIFTUI_NEXT_VERSION]
+    /// - Since: 1.1.0 (SendbirdSwiftUI)
     var isQuoteReplyingMode = false
     
     // MARK: - Life cycle


### PR DESCRIPTION
# SendbirdUIKit
### Improvements and Deprecations
We have fixed autolayout warnings. 
In the process, we have improved message cell types to be registered based on Metatypes, instead of instances. 
Accordingly, the below interfaces in `SBUGroupChannelModule.List` have been deprecated. 
- `open func register(adminMessageCell:nib:)`
- `open func register(userMessageCell:nib:)` 
- `open func register(fileMessageCell:nib:)` 
- `open func register(multipleFilesMessageCell:nib:)` 
- `open func register(typingIndicatorMessageCell:nib:)` 
- `open func register(unknownMessageCell:nib:)`   
- `open func register(customMessageCell:nib:)`     

# SendbirdUIMessageTemplate
- none