### PR TITLE
Release/3.34.0 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+### v3.34.0 (Feb 13, 2026)
+
+# SendbirdUIKit
+
+## New Feature
+### Liquid Glass Support (iOS 26+)
+
+SendbirdUIKit now supports Apple's Liquid Glass design introduced in iOS 26. When running on iOS 26+, liquid glass styling is applied automatically across navigation bars, message input views, alert views, menus, and channel list headers.
+
+**Opting Out**
+
+Liquid glass is enabled by default on iOS 26+. To disable it and use the classic appearance:
+```swift
+  SendbirdUI.config.common.isLiquidGlassEnabled = false
+```
+
+**What's Affected**
+The below components have been updated to support liquid glass styling:
+- Navigation bars
+- Message input view
+- Alert views
+- Menu views (for when long-pressing messages)
+- "Create channel" context menu in GroupChannelList Header
 ### v3.33.1 (Feb 03, 2026)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -25,13 +25,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.33.1/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "b55c89d32f9634270be305c92fc67c0c0b04c23328d4f9436e55037dce3ec9ca" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "fbc41adc410b034454fe2b507a0c6b5bbb42c4f4963c438951c94c0a46c39cca" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.33.1/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "99be28b7f9e23a5749f28565362a335e709d2752fada6af15032879882f69542" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "8fb8dd6c05ce84eab5754ed91da7f5ef5e104d60e39ef75c4f995cc618b693f4" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",

--- a/Sample/QuickStart.xcodeproj/project.pbxproj
+++ b/Sample/QuickStart.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		24A5AE640B6515C62919F289 /* SBUOpenChannelUnknownMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A67C47244DA26ACA2C1379F /* SBUOpenChannelUnknownMessageCell.swift */; };
 		24B9B0D5DB8619080A104320 /* CustomEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE6549CE553EFCA6E649E6F /* CustomEmptyView.swift */; };
 		25555C45F39E5B3FF531DDA0 /* SBUModerationsViewModel.Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F543820720E0E370AF1A80 /* SBUModerationsViewModel.Deprecated.swift */; };
+		2608A3A8438EED2589A2E613 /* SBULiquidGlassUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01788854AA2E72A56D48343 /* SBULiquidGlassUtils.swift */; };
 		26E4610C458D4977952E3BBB /* UIViewController+SBUIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E1A219E09610EE8505C8D5 /* UIViewController+SBUIKit.swift */; };
 		2711AD316AE0C638DBFBCF70 /* SBUOpenChannelSettingsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A715F917D8AE61996FAD75F /* SBUOpenChannelSettingsModule.swift */; };
 		275B5DD48EF10994D39ADD4B /* SBUMessageInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E964FBEE2748E71B6F01AC9 /* SBUMessageInputView.swift */; };
@@ -421,6 +422,7 @@
 		C8F78FC3E5368E0F50609DDF /* SBUMessageCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5A06ADD6946C8BF00324 /* SBUMessageCellProtocol.swift */; };
 		C8FE517E396D40081B5ADA00 /* SBUGroupChannelSettingsModule.List.swift in Sources */ = {isa = PBXBuildFile; fileRef = F450F6B99019EB9DC6BFDDB9 /* SBUGroupChannelSettingsModule.List.swift */; };
 		C96C938EB6943338326CEEAA /* AIChatBotSignInViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FBCECAC20501BC1FA624C11C /* AIChatBotSignInViewController.xib */; };
+		CA95FA81F95B2ADDAF2E3843 /* UIBarButtonItem+SBUIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87CA06988032A7CACD7FC98 /* UIBarButtonItem+SBUIKit.swift */; };
 		CAC62317F3638B33C39E643B /* SBUContentBaseMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1D5CF4D3833B6FB84EBFAB /* SBUContentBaseMessageCell.swift */; };
 		CBA903BC5423000FF3A2B6A5 /* ChannelVC_MessageParam.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39ED93546A3FDE91D6A3EF6F /* ChannelVC_MessageParam.swift */; };
 		CC170FDE95832FD90177CB31 /* SBUOpenChannelListModule.Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8DEA5DC72F4F466A859911 /* SBUOpenChannelListModule.Deprecated.swift */; };
@@ -494,6 +496,7 @@
 		E3FD533D822BAE4E52099705 /* SBUTypingIndicatorBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED15BE91F7D6B5947C325A54 /* SBUTypingIndicatorBubbleView.swift */; };
 		E477B7A6A612AB534869F6A5 /* SBUUserNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F80A3F363B14916DD1409A /* SBUUserNameView.swift */; };
 		E5507EBC7A1938E8D4759445 /* SBUExtendedMessagePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B162DB9A0ECD130CF46DCC2E /* SBUExtendedMessagePayload.swift */; };
+		E6175B1E6A816C0625F975D5 /* UIVisualEffectView+SBUIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AAED35A67B41ED1188DCE /* UIVisualEffectView+SBUIKit.swift */; };
 		E68BDB1C096C0BF93C8EA3D9 /* SBUInviteUserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A714261310094C634F64A8C /* SBUInviteUserViewModel.swift */; };
 		E76209DE1873B4FB76B34983 /* ChannelVC_Overriding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7C1654C625423EEF5E5B64 /* ChannelVC_Overriding.swift */; };
 		E7BC49C23E88D53C736C0380 /* SBUOpenChannelListModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7492A0683583120AF0A9E9A /* SBUOpenChannelListModule.swift */; };
@@ -662,6 +665,7 @@
 		247831C3DF2D28C309632F55 /* UIScrollView+SBUIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+SBUIKit.swift"; sourceTree = "<group>"; };
 		254D891AE9CDFE3A829B3DC7 /* FeedChannelListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelListViewController.swift; sourceTree = "<group>"; };
 		2567BDE4720A6C46C81282D5 /* SBUChannelSettingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUChannelSettingItem.swift; sourceTree = "<group>"; };
+		261AAED35A67B41ED1188DCE /* UIVisualEffectView+SBUIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVisualEffectView+SBUIKit.swift"; sourceTree = "<group>"; };
 		2628AA835EFFD20C7225B817 /* SBUNotificationTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUNotificationTimelineView.swift; sourceTree = "<group>"; };
 		268FDB1348A09BE4D0F8E284 /* SBUContentBaseMessageCell.Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUContentBaseMessageCell.Deprecated.swift; sourceTree = "<group>"; };
 		26B3A0BDFAE02540461DFD20 /* SBUChannelInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUChannelInfoHeaderView.swift; sourceTree = "<group>"; };
@@ -980,6 +984,7 @@
 		B6F6D268A4007EB509EF9AF3 /* SBUFeedbackViewParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUFeedbackViewParams.swift; sourceTree = "<group>"; };
 		B7336ED3EEE080DDF052F158 /* LiveStreamChannelCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStreamChannelCell.swift; sourceTree = "<group>"; };
 		B843A0434E093A9F5B7FF7C9 /* SBUVoiceRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUVoiceRecorder.swift; sourceTree = "<group>"; };
+		B87CA06988032A7CACD7FC98 /* UIBarButtonItem+SBUIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+SBUIKit.swift"; sourceTree = "<group>"; };
 		B943C8F50DD6CA3985E33CF6 /* GeneralSignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSignInViewController.swift; sourceTree = "<group>"; };
 		B975A667F21E2131BCF0BD88 /* SBUViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUViewModelDelegate.swift; sourceTree = "<group>"; };
 		B9B83184330EB69949766896 /* SBUAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUAlertView.swift; sourceTree = "<group>"; };
@@ -1025,6 +1030,7 @@
 		CE734900FAB830172C9AC91B /* SBUBaseChannelSettingsViewController.Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUBaseChannelSettingsViewController.Deprecated.swift; sourceTree = "<group>"; };
 		CF0978D8366FFC1C1505AEC4 /* UIImage+SBUIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+SBUIKit.swift"; sourceTree = "<group>"; };
 		CF9A846392BBAAD801EE5844 /* SBUQuotedFileMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUQuotedFileMessageView.swift; sourceTree = "<group>"; };
+		D01788854AA2E72A56D48343 /* SBULiquidGlassUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBULiquidGlassUtils.swift; sourceTree = "<group>"; };
 		D0E72BA73F5F535E85BA2187 /* SBUChatNotificationChannelModule.Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUChatNotificationChannelModule.Deprecated.swift; sourceTree = "<group>"; };
 		D20874B23A811B56CB760379 /* SBUBaseSelectUserModule.List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBUBaseSelectUserModule.List.swift; sourceTree = "<group>"; };
 		D22C301C4940E6DCA7C64C8D /* BasicUsagesView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BasicUsagesView.xib; sourceTree = "<group>"; };
@@ -2320,6 +2326,7 @@
 			children = (
 				73117A4E25609D7F0330EB6D /* BlockingOperation.swift */,
 				3263794888EC7E1A2E8E57B9 /* SBUDebouncer.swift */,
+				D01788854AA2E72A56D48343 /* SBULiquidGlassUtils.swift */,
 				0F761A114B237606F8044C82 /* SBULogger.swift */,
 				9CBD97006461735D039F9AEC /* SBUMentionManager.swift */,
 				113481A67B467FA354146A3E /* SBUPropertyWrapper.swift */,
@@ -2568,6 +2575,7 @@
 				AE6A829159D54B056985C36F /* String+SBUIKit.swift */,
 				841EF97C03733C94215BA84B /* Thread+SBUIKit.swift */,
 				C53E83DBE3CAEACD71D845C6 /* UIApplication+SBUIKit.swift */,
+				B87CA06988032A7CACD7FC98 /* UIBarButtonItem+SBUIKit.swift */,
 				16160F715B15DD731A2DC946 /* UIColor+SBUIKit.swift */,
 				CF0978D8366FFC1C1505AEC4 /* UIImage+SBUIKit.swift */,
 				2E617446DE7DFE58F1AC62FA /* UIImageView+SBUIKit.swift */,
@@ -2798,6 +2806,7 @@
 				E5EA0243169F0C368F1E3446 /* UITableView+SBUIKit.swift */,
 				423C436B860E07BBEF78BE8C /* UITextField+SBUIKit.swift */,
 				B1E1A219E09610EE8505C8D5 /* UIViewController+SBUIKit.swift */,
+				261AAED35A67B41ED1188DCE /* UIVisualEffectView+SBUIKit.swift */,
 				382CD1F786A2D39C69D42BC6 /* URL+SBUIKit.swift */,
 				6A4225413BACFBCC503290A1 /* ChatSDK */,
 				A88DE179B2DDF42F66CAEEFE /* Shared */,
@@ -3566,6 +3575,7 @@
 				39C7465C48799AB15F61D705 /* SBULabel.swift in Sources */,
 				C163F4689021B06762CD0645 /* SBULayoutableButton.swift in Sources */,
 				6B4AB61D836E0B30A9FD2950 /* SBULinkClickableTextView.swift in Sources */,
+				2608A3A8438EED2589A2E613 /* SBULiquidGlassUtils.swift in Sources */,
 				A239F462DB4AB885C0CD3A51 /* SBULoading.swift in Sources */,
 				51C45CE30D4211ED127A9084 /* SBULogger.swift in Sources */,
 				2193672786394505EDEBAAA7 /* SBUMarginView.swift in Sources */,
@@ -3784,6 +3794,7 @@
 				D8F51A2D59160ED7E53137EC /* StringProtocol+SBUIKit.swift in Sources */,
 				C8A352346B8A1B7530A1A7D4 /* Thread+SBUIKit.swift in Sources */,
 				BD9991935895BC94F1882B8B /* UIApplication+SBUIKit.swift in Sources */,
+				CA95FA81F95B2ADDAF2E3843 /* UIBarButtonItem+SBUIKit.swift in Sources */,
 				079D10006B04CCDEBA6CB7AB /* UIButton+SBUIKit.swift in Sources */,
 				16AFBC90566C39F6AA629311 /* UICollectionView+SBUIKit.swift in Sources */,
 				E070F2F1374C1A6E8AC712A0 /* UIColor+SBUIKit.swift in Sources */,
@@ -3800,6 +3811,7 @@
 				EAB9B1A42F4598FC8A9141CC /* UIView+Ext.swift in Sources */,
 				DFB94B0DA7E034C037A5145E /* UIView+SBUIKit.swift in Sources */,
 				26E4610C458D4977952E3BBB /* UIViewController+SBUIKit.swift in Sources */,
+				E6175B1E6A816C0625F975D5 /* UIVisualEffectView+SBUIKit.swift in Sources */,
 				A0875C861E06C0E0796252CE /* UIcolor+Ext.swift in Sources */,
 				F857C6562F46F665A4C788BF /* URL+SBUIKit.swift in Sources */,
 				E022C39DAE8F104CB09DD281 /* UserDefaults+Ext.swift in Sources */,
@@ -3857,7 +3869,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.1;
+				MARKETING_VERSION = 3.34.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -3885,7 +3897,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.1;
+				MARKETING_VERSION = 3.34.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4030,7 +4042,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.1;
+				MARKETING_VERSION = 3.34.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4058,7 +4070,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.1;
+				MARKETING_VERSION = 3.34.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.uikit.sample.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -4107,7 +4119,7 @@
 			repositoryURL = "https://github.com/sendbird/sendbird-uikit-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.33.1;
+				minimumVersion = 3.34.0;
 			};
 		};
 		A4CD81EE92C875D0E22463C6 /* XCRemoteSwiftPackageReference "sendbird-chat-sdk-ios" */ = {

--- a/Sample/project.yml
+++ b/Sample/project.yml
@@ -11,7 +11,7 @@ packages:
     from: 4.35.0
   SendbirdUIKit:
     url: https://github.com/sendbird/sendbird-uikit-ios-spm
-    from: 3.33.1
+    from: 3.34.0
 schemes:
   QuickStart:
     analyze:
@@ -38,7 +38,7 @@ settingGroups:
     FRAMEWORK_SEARCH_PATHS: ''
     IPHONEOS_DEPLOYMENT_TARGET: '13.0'
     LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
-    MARKETING_VERSION: '3.33.1'
+    MARKETING_VERSION: '3.34.0'
     PRODUCT_NAME: "$(TARGET_NAME)"
     SDKROOT: iphoneos
     SWIFT_VERSION: '5.0'

--- a/SendBirdUIKit.podspec
+++ b/SendBirdUIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "SendBirdUIKit"
-	s.version = "3.33.1"
+	s.version = "3.34.0"
 	s.summary = "UIKit based on SendbirdChatSDK"
 	s.description = "Sendbird UIKit is a framework composed of basic UI components based on SendbirdChatSDK."
 	s.homepage = "https://sendbird.com"
@@ -16,11 +16,11 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "7bfb201ad6294b6812e8a4c263ce8277349a03b8" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendBirdUIKit.zip", :sha1 => "d33c19561834f0bf4393411fd81543d4b95dc369" }
 	s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true
 	s.dependency "SendbirdChatSDK", ">= 4.35.0"
-	s.dependency "SendbirdUIMessageTemplate", ">= 3.33.1"
+	s.dependency "SendbirdUIMessageTemplate", ">= 3.34.0"
 	s.ios.library = "icucore"
 end

--- a/SendbirdUIMessageTemplate.podspec
+++ b/SendbirdUIMessageTemplate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "SendbirdUIMessageTemplate"
-	s.version = "3.33.1"
+	s.version = "3.34.0"
 	s.summary = "SendbirdUIMessageTemplate based on SendbirdChatSDK"
 	s.description = "Sendbird UI MessageTemplate is a framework composed of basic Message Template UI components based on SendbirdChatSDK."
 	s.homepage = "https://sendbird.com"
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 	"Kai" => "kai.lee@sendbird.com"
   	}
 	s.platform = :ios, "13.0"
-	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "f6398d8d0659c56e2e3d234cea4d335a762ca296" }
+	s.source = { :http => "https://github.com/sendbird/sendbird-uikit-ios/releases/download/#{s.version}/SendbirdUIMessageTemplate.zip", :sha1 => "7d11e4c4b8f1dd64d210e13702d3dca6f7231db0" }
 	s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
 	s.ios.frameworks = ["UIKit", "Foundation", "CoreData", "SendbirdChatSDK"]
 	s.requires_arc = true

--- a/Sources/Configuration/SBUConfig.Common.swift
+++ b/Sources/Configuration/SBUConfig.Common.swift
@@ -16,6 +16,32 @@ extension SBUConfig {
         /// When clicking on a user profile image in the channel or user list, utilize the mini profile popup.
         @SBUPrioritizedConfig public var isUsingDefaultUserProfileEnabled: Bool = false
         
+        /// - Since: 3.34.0
+        private var _isLiquidGlassEnabled: Bool = true
+
+        /// Set this to `false` to disable liquid glass style in iOS 26.0+.
+        /// Defaults to `true`.
+        /// - Since: 3.34.0
+        @available(iOS 26.0, *)
+        public var isLiquidGlassEnabled: Bool {
+            get { _isLiquidGlassEnabled }
+            set { _isLiquidGlassEnabled = newValue }
+        }
+
+        /// Flag that checks if liquid glass should be applied or not.
+        /// - Since: 3.34.0
+        var shouldApplyLiquidGlass: Bool {
+            #if compiler(>=6.2)
+            if #available(iOS 26.0, *) {
+                return self.isLiquidGlassEnabled
+            } else {
+                return false
+            }
+            #else
+            return false
+            #endif 
+        }
+        
         // MARK: Logic
         override init() {}
         

--- a/Sources/Constant/SBUConstant.swift
+++ b/Sources/Constant/SBUConstant.swift
@@ -65,4 +65,16 @@ class SBUConstant {
     // For typing indicator bubble.
     static let maxNumberOfProfileImages: Int = 3
     static let maxNumberOfTypers: Int = 102
+    
+    // For message input bottom spacing
+    
+    /// MessageInputView bottom edge <-> ViewController bottom edge
+    /// - Since: 3.34.0
+    @SBUAdaptive(base: 0, liquidGlass: 20)
+    static var messageInputViewBottomSpacing: CGFloat
+    
+    /// MessageInputView bottom edge <-> keyboard top edge
+    /// - Since: 3.34.0
+    @SBUAdaptive(base: 0, liquidGlass: 10)
+    static var messageInputViewKeyboardSpacing: CGFloat
 }

--- a/Sources/Constant/SBUStringSet.swift
+++ b/Sources/Constant/SBUStringSet.swift
@@ -344,6 +344,10 @@ public class SBUStringSet {
     public static var ChannelType_SuperGroup = "Super group"
     public static var ChannelType_Broadcast = "Broadcast"
     
+    public static var ChannelType_GroupChannel = "Group channel"
+    public static var ChannelType_SuperGroupChannel = "Super group channel"
+    public static var ChannelType_BroadcastChannel = "Broadcast channel"
+    
     // MARK: - form type
     public static var FormType_Optional = "(optional)" // 3.11.0
     public static var FormType_Error_Default = "Please check the value" // 3.11.0

--- a/Sources/Enums/SBUIconSetType.swift
+++ b/Sources/Enums/SBUIconSetType.swift
@@ -95,6 +95,15 @@ public enum SBUIconSetType: String, Hashable {
         public static let iconUserProfileInChat = CGSize(value: 15)
         public static let iconChevronDown = CGSize(value: 22)
         public static let iconVoiceMessageSize = CGSize(value: 20)
+        
+        /// - Since: 3.34.0
+        @SBUAdaptive(base: CGSize(value: 24), liquidGlass: CGSize(value: 22))
+        public static var defaultIconSizeAdaptive
+        
+        /// - Since: 3.34.0
+        public static let iconPaddingLiquidGlass: CGFloat = 3
+        /// - Since: 3.34.0
+        public static let iconSizeLiquidGlass: CGFloat = 22
     }
     
     // MARK: - Image handling

--- a/Sources/Extension/Shared/UIBarButtonItem+SBUIKit.swift
+++ b/Sources/Extension/Shared/UIBarButtonItem+SBUIKit.swift
@@ -1,0 +1,16 @@
+//
+//  UIBarButtonItem+SBUIKit.swift
+//  SendbirdUIKit
+//
+//  Created by Celine Moon on 2/4/26.
+//
+
+import UIKit
+
+extension UIBarButtonItem {
+    /// Checks if `UIBarButtonItem` is created via `.init()` with no content.
+    /// - Since: 3.34.0
+    var isEmpty: Bool {
+        return image == nil && title == nil && customView == nil
+    }
+}

--- a/Sources/Extension/Shared/UIImage+SBUIKit.swift
+++ b/Sources/Extension/Shared/UIImage+SBUIKit.swift
@@ -107,10 +107,30 @@ public extension UIImage {
     ///
     /// - Parameter color: The color to fill the image with.
     /// - Returns: A `UIImage` object filled with the specified color.
-    /// 
+    ///
     /// - Since: 3.22.0
     static func sbu_from(color: UIColor) -> UIImage {
         UIImage.from(color: color)
+    }
+
+    /// Adds a circular background around the image by extending the canvas size.
+    ///
+    /// Unlike `sbu_withBackground` which keeps the canvas size and shrinks the icon,
+    /// this method EXPANDS the canvas by adding padding around the original image,
+    /// keeping the icon at its original size.
+    ///
+    /// - Parameters:
+    ///   - color: The background color for the circular area.
+    ///   - padding: The padding to add around all sides of the image. The final image size will be `(originalSize + padding * 2)`.
+    /// - Returns: A new image with the circular background added around the original image.
+    ///
+    /// Example: A 22x22 icon with padding of 3 results in a 28x28 image with:
+    /// - A 28pt diameter circle as background
+    /// - The original 22x22 icon centered inside
+    ///
+    /// - Since: 3.34.0
+    func sbu_addCircularBackgroundPadding(_ padding: CGFloat, color: UIColor) -> UIImage {
+        self.addCircularBackgroundPadding(padding, color: color)
     }
 }
 
@@ -191,10 +211,10 @@ extension UIImage {
     
     func withBackground(color: UIColor, margin: CGFloat, circle: Bool = false) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false, scale)
-        
+
         guard let context = UIGraphicsGetCurrentContext(), let image = cgImage else { return self }
         defer { UIGraphicsEndImageContext() }
-        
+
         let backgroundRect = CGRect(origin: .zero, size: size)
         context.setFillColor(color.cgColor)
 
@@ -214,7 +234,43 @@ extension UIImage {
             size: .init(width: self.size.width - margin*2, height: self.size.height - margin*2)
         )
         context.draw(image, in: imageRect)
-        
+
+        return UIGraphicsGetImageFromCurrentImageContext() ?? self
+    }
+    
+    /// For documentation, see ``sbu_addCircularBackgroundPadding(_:color:)``
+    /// 3.34.0
+    func addCircularBackgroundPadding(_ padding: CGFloat, color: UIColor) -> UIImage {
+        let expandedSize = CGSize(
+            width: size.width + padding * 2,
+            height: size.height + padding * 2
+        )
+
+        UIGraphicsBeginImageContextWithOptions(expandedSize, false, scale)
+
+        guard let context = UIGraphicsGetCurrentContext(), let image = cgImage else { return self }
+        defer { UIGraphicsEndImageContext() }
+
+        // Draw circular background on the expanded canvas
+        let backgroundRect = CGRect(origin: .zero, size: expandedSize)
+        context.setFillColor(color.cgColor)
+
+        let radiusSize = min(expandedSize.width, expandedSize.height)
+        let clipPath = UIBezierPath(roundedRect: backgroundRect, cornerRadius: radiusSize / 2).cgPath
+        context.addPath(clipPath)
+        context.closePath()
+        context.fillPath()
+
+        // Flip the coordinate system for drawing the image
+        context.concatenate(CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: expandedSize.height))
+
+        // Draw the original image centered (with padding offset)
+        let imageRect = CGRect(
+            origin: CGPoint(x: padding, y: padding),
+            size: size
+        )
+        context.draw(image, in: imageRect)
+
         return UIGraphicsGetImageFromCurrentImageContext() ?? self
     }
     

--- a/Sources/Extension/UIVisualEffectView+SBUIKit.swift
+++ b/Sources/Extension/UIVisualEffectView+SBUIKit.swift
@@ -1,0 +1,51 @@
+//
+//  UIVisualEffectView+SBUIKit.swift
+//  SendbirdUIKit
+//
+//  Created by Celine Moon on 1/20/26.
+//
+
+import UIKit
+
+// MARK: - Liquid Glass
+
+extension UIVisualEffectView {
+
+    /// Applies layout properties for liquid glass style.
+    /// - Parameters:
+    ///   - frame: The frame to set.
+    ///   - autoresizingMask: The autoresizing mask to set.
+    /// - Since: 3.34.0
+    func setupLayouts(
+        frame: CGRect?,
+        autoresizingMask: UIView.AutoresizingMask?
+    ) {
+        if let frame = frame {
+            self.frame = frame
+        }
+        if let autoresizingMask = autoresizingMask {
+            self.autoresizingMask = autoresizingMask
+        }
+    }
+
+    /// Applies style properties for liquid glass style.
+    /// - Parameters:
+    ///   - cornerRadius: The corner radius to apply.
+    ///   - cornerCurve: The corner curve style.
+    /// - Since: 3.34.0
+    func setupStyles(
+        cornerRadius: CGFloat?,
+        cornerCurve: CALayerCornerCurve?,
+        clipsToBounds: Bool?
+    ) {
+        if let cornerRadius {
+            self.layer.cornerRadius = cornerRadius
+        }
+        if let cornerCurve {
+            self.layer.cornerCurve = cornerCurve
+        }
+        if let clipsToBounds {
+            self.clipsToBounds = clipsToBounds
+        }
+    }
+}

--- a/Sources/Module/Channel/GroupChannel/SBUGroupChannelModule.List.swift
+++ b/Sources/Module/Channel/GroupChannel/SBUGroupChannelModule.List.swift
@@ -450,8 +450,9 @@ extension SBUGroupChannelModule {
         open override func setupLayouts() {
             super.setupLayouts()
             
+            var userSafeArea = SendbirdUI.config.common.shouldApplyLiquidGlass
             self.topStackView
-                .sbu_constraint(equalTo: self, leading: 8, trailing: -8, top: 8)
+                .sbu_constraint(equalTo: self, leading: 8, trailing: -8, top: 8, useSafeArea: userSafeArea)
             
             channelStateBanner?.sbu_constraint(height: 24)
             channelStateBanner?.sbu_constraint(equalTo: topStackView, leading: 0, trailing: 0)
@@ -466,7 +467,13 @@ extension SBUGroupChannelModule {
                     width: SBUConstant.scrollBottomButtonSize.width,
                     height: SBUConstant.scrollBottomButtonSize.height
                 )
-                .sbu_constraint(equalTo: self, trailing: -16, bottom: 8)
+                .sbu_constraint(equalTo: self, trailing: -16)
+
+            // For liquid glass mode, bottom constraint is set in SBUGroupChannelViewController
+            // relative to the input component
+            if !SendbirdUI.config.common.shouldApplyLiquidGlass {
+                self.scrollBottomView?.sbu_constraint(equalTo: self, bottom: 8)
+            }
         }
         
         /// Updates styles of the views in the list component with the `theme`.

--- a/Sources/Module/Channel/OpenChannel/SBUOpenChannelModule.List.swift
+++ b/Sources/Module/Channel/OpenChannel/SBUOpenChannelModule.List.swift
@@ -164,7 +164,11 @@ extension SBUOpenChannelModule {
                         height: SBUConstant.scrollBottomButtonSize.height
                     )
                     .sbu_constraint(equalTo: self, trailing: -16)
-                    .sbu_constraint(equalTo: self, bottom: 8)
+
+                // For liquid glass mode, bottom constraint is set in SBUOpenChannelViewController
+                if !SendbirdUI.config.common.shouldApplyLiquidGlass {
+                    scrollBottomView.sbu_constraint(equalTo: self, bottom: 8)
+                }
             }
         }
         

--- a/Sources/Module/Channel/SBUBaseChannelModule.List.swift
+++ b/Sources/Module/Channel/SBUBaseChannelModule.List.swift
@@ -453,6 +453,17 @@ extension SBUBaseChannelModule {
                 self.theme = theme
             }
             
+            // Liquid glass support
+            #if compiler(>=6.2)
+            if #available(iOS 26.0, *), SendbirdUI.config.common.shouldApplyLiquidGlass {
+                self.tableView.topEdgeEffect.isHidden = true
+                self.tableView.bottomEdgeEffect.isHidden = true
+                
+                self.tableView.contentInsetAdjustmentBehavior = .never
+                self.tableView.showsVerticalScrollIndicator = false
+            }
+            #endif
+            
             switch self.channelStateBanner {
             case let banner as SBUChannelStateBanner:
                 banner.setupStyles(theme: theme)
@@ -511,6 +522,10 @@ extension SBUBaseChannelModule {
         }
         
         // MARK: - TableView
+        public func updateTableViewContentInset(insets: UIEdgeInsets) {
+            self.tableView.contentInset = insets
+        }
+        
         /// Reloads table view. This method corresponds to `UITableView reloadData()`.
         public func reloadTableView(needsToLayout: Bool = true) {
             if let gropuChannelModuleList = self as? SBUGroupChannelModule.List {
@@ -943,10 +958,12 @@ extension SBUBaseChannelModule {
         }
         
         // MARK: - UITableViewDelegate, UITableViewDataSource
+        
         /// Called when the `scrollView` has been scrolled.
         open func scrollViewDidScroll(_ scrollView: UIScrollView) {
             guard scrollView == self.tableView else { return }
             self.baseDelegate?.baseChannelModule(self, didScroll: scrollView)
+            
         }
         
         open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -1150,7 +1167,7 @@ extension SBUBaseChannelModule.List: SBUUserProfileViewDelegate {
 extension SBUBaseChannelModule.List {
     /// This property checks if the scroll is near the bottom of the screen.
     public var isScrollNearByBottom: Bool {
-        tableView.contentOffset.y < 10
+        tableView.contentOffset.y + tableView.contentInset.top < 10
     }
     
     /// To keep track of which scrolls tableview.

--- a/Sources/Module/ChannelList/GroupChannel/SBUGroupChannelListModule.Header.swift
+++ b/Sources/Module/ChannelList/GroupChannel/SBUGroupChannelListModule.Header.swift
@@ -10,8 +10,36 @@ import UIKit
 import SwiftUI
 import SendbirdChatSDK
 
+/// Represents the type of group channel to create from the channel list.
+/// - Since: 3.34.0
+public enum SBUCreateGroupChannelType {
+    /// A standard group channel.
+    case group
+    /// A super group channel that supports a large number of members.
+    case superGroup
+    /// A broadcast channel where only operators can send messages.
+    case broadcast
+}
+
 /// Event methods for the views updates and performing actions from the header component in group channel list module.
-public protocol SBUGroupChannelListModuleHeaderDelegate: SBUBaseChannelListModuleHeaderDelegate {}
+public protocol SBUGroupChannelListModuleHeaderDelegate: SBUBaseChannelListModuleHeaderDelegate {
+    /// Method that gets called when user selects a channel type from the create channel context menu.
+    /// - Parameters:
+    ///   - headerComponent: The header component where the selection was made.
+    ///   - type: The type of channel to create.
+    /// - Since: 3.34.0
+    func groupChannelListModule(
+        _ headerComponent: SBUBaseChannelListModule.Header,
+        didSelectCreateChannelType type: SBUCreateGroupChannelType
+    )
+}
+
+extension SBUGroupChannelListModuleHeaderDelegate {
+    func groupChannelListModule(
+        _ headerComponent: SBUBaseChannelListModule.Header,
+        didSelectCreateChannelType type: SBUCreateGroupChannelType
+    ) { }
+}
 
 extension SBUGroupChannelListModule {
     /// A module component that represents the header of `SBUGroupChannelListModule`.
@@ -48,13 +76,56 @@ extension SBUGroupChannelListModule {
         }
         
         override func createDefaultRightButton() -> SBUBarButtonItem {
-            SBUModuleSet.GroupChannelListModule.HeaderComponent.RightBarButton.init(
+            let buttonAction: Selector?
+            if SendbirdUI.config.common.shouldApplyLiquidGlass {
+                buttonAction = nil
+            } else {
+                buttonAction = #selector(onTapRightBarButton)
+            }
+            
+            return SBUModuleSet.GroupChannelListModule.HeaderComponent.RightBarButton.init(
                 image: SBUIconSetType.iconCreate.image(to: SBUIconSetType.Metric.defaultIconSize),
                 landscapeImagePhone: nil,
                 style: .plain,
                 target: self,
-                action: #selector(onTapRightBarButton)
+                action: buttonAction
             )
+        }
+        
+        /// - Since: 3.34.0
+        @available(iOS 26, *)
+        func makeCreateChannelTypeContextMenu() -> UIMenu? {
+            let tintColor = theme?.channelTypeSelectorItemTintColor
+
+            let group = UIAction(
+                title: SBUStringSet.ChannelType_GroupChannel,
+                image: SBUIconSetType.iconChat.image(
+                    with: tintColor,
+                    to: SBUIconSetType.Metric.defaultIconSizeSmall
+                )
+            ) { _ in
+                self.delegate?.groupChannelListModule(self, didSelectCreateChannelType: .group)
+            }
+            let superGroup = UIAction(
+                title: SBUStringSet.ChannelType_SuperGroupChannel,
+                image: SBUIconSetType.iconSupergroup.image(
+                    with: tintColor,
+                    to: SBUIconSetType.Metric.defaultIconSizeSmall
+                )
+            ) { _ in
+                self.delegate?.groupChannelListModule(self, didSelectCreateChannelType: .superGroup)
+            }
+            let broadcast = UIAction(
+                title: SBUStringSet.ChannelType_BroadcastChannel,
+                image: SBUIconSetType.iconBroadcast.image(
+                    with: tintColor,
+                    to: SBUIconSetType.Metric.defaultIconSizeSmall
+                )
+            ) { _ in
+                self.delegate?.groupChannelListModule(self, didSelectCreateChannelType: .broadcast)
+            }
+
+            return UIMenu(title: "Channel type", children: [group, superGroup, broadcast])
         }
         
         // MARK: - LifeCycle
@@ -92,6 +163,11 @@ extension SBUGroupChannelListModule {
             
             // uikit 
             super.setupViews()
+            
+            
+            if #available(iOS 26, *), SendbirdUI.config.common.shouldApplyLiquidGlass {
+                rightBarButton?.menu = self.makeCreateChannelTypeContextMenu()
+            }
         }
         
         /// Sets up style with theme. If the `theme` is `nil`, it uses the stored theme.

--- a/Sources/Module/ChannelList/GroupChannel/SBUGroupChannelListModule.List.swift
+++ b/Sources/Module/ChannelList/GroupChannel/SBUGroupChannelListModule.List.swift
@@ -112,6 +112,13 @@ extension SBUGroupChannelListModule {
             }
             self.tableView.backgroundColor = self.theme?.backgroundColor
             
+            #if compiler(>=6.2)
+            if SendbirdUI.config.common.shouldApplyLiquidGlass, #available(iOS 26.0, *) {
+                self.tableView.topEdgeEffect.isHidden = true
+                self.tableView.bottomEdgeEffect.isHidden = false
+            }
+            #endif
+            
             (self.emptyView as? SBUEmptyView)?.setupStyles()
         }
         

--- a/Sources/Module/ChannelList/OpenChannel/SBUOpenChannelListModule.List.swift
+++ b/Sources/Module/ChannelList/OpenChannel/SBUOpenChannelListModule.List.swift
@@ -119,6 +119,13 @@ extension SBUOpenChannelListModule {
             }
             self.tableView.backgroundColor = self.theme?.backgroundColor
             
+            #if compiler(>=6.2)
+            if SendbirdUI.config.common.shouldApplyLiquidGlass, #available(iOS 26.0, *) {
+                self.tableView.topEdgeEffect.isHidden = true
+                self.tableView.bottomEdgeEffect.isHidden = false
+            }
+            #endif
+            
             (self.emptyView as? SBUEmptyView)?.setupStyles()
             
             if isPullToRefreshEnabled {

--- a/Sources/Theme/SBUColorSet.swift
+++ b/Sources/Theme/SBUColorSet.swift
@@ -36,9 +36,17 @@ public class SBUColorSet {
     public static var background600 = UIColor(white: 22.0 / 255.0, alpha: 1.0)
     public static var background700 = UIColor(white: 0.0, alpha: 1.0)
     
+    public static var background0 = UIColor.clear  // 3.34.0
+    public static var buttonBackgroundLight = UIColor(red: 120.0 / 255.0, green: 120.0 / 255.0, blue: 128.0 / 255.0, alpha: 0.16)
+    public static var buttonHighlightedBackgroundLight = UIColor(red: 120.0 / 255.0, green: 120.0 / 255.0, blue: 128.0 / 255.0, alpha: 0.16)
+    public static var buttonBackgroundDark = UIColor(red: 120.0 / 255.0, green: 120.0 / 255.0, blue: 128.0 / 255.0, alpha: 0.16)
+    public static var buttonHighlitedBackgroundDark = UIColor(red: 120.0 / 255.0, green: 120.0 / 255.0, blue: 128.0 / 255.0, alpha: 0.16)
+    
     // MARK: - Overlay
     public static var overlayDark = UIColor(white: 0.0, alpha: 0.55)
     public static var overlayLight = UIColor(white: 0.0, alpha: 0.32)
+    
+    public static var overlayDarkLiquidGlass = UIColor(red: 41.0 / 255.0, green: 41.0 / 255.0, blue: 58.0 / 255.0, alpha: 0.23)
     
     // MARK: - On Light
     public static var onLightTextHighEmphasis = UIColor(white: 0.0, alpha: 0.88)
@@ -68,6 +76,21 @@ public class SBUColorSet {
 
     // MARK: - Highlight
     public static var highlight = UIColor(red: 1.0, green: 242.0 / 255.0, blue: 182.0 / 255.0, alpha: 1.0)
+    
+    // MARK: - Liquid glass
+    /// - Since: 3.34.0
+    public static var liquidGlassMenuViewShadowLight = SBUColorSet.background50.withAlphaComponent(0.08)
+    /// - Since: 3.34.0
+    public static var liquidGlassMenuViewShadowDark = SBUColorSet.background700.withAlphaComponent(0.08)
+    
+    /// - Since: 3.34.0
+    public static var liquidGlassButtonHighlightLight = SBUColorSet.background50.withAlphaComponent(0.7)
+    public static var liquidGlassButtonHighlightDark = SBUColorSet.background700.withAlphaComponent(0.35)
+    
+    /// - Since: 3.34.0
+    public static var liquidGlassInputButtonBackgroundLight = UIColor(red: 0, green: 0, blue: 0, alpha: 0.03)
+    /// - Since: 3.34.0
+    public static var liquidGlassInputButtonBackgroundDark = UIColor(white: 1.0, alpha: 0.03)
 }
 
 extension SBUColorSet {

--- a/Sources/Theme/SBUFontSet.swift
+++ b/Sources/Theme/SBUFontSet.swift
@@ -30,7 +30,8 @@ public class SBUFontSet {
             .paragraphStyle: style
         ]
     }()
-    /// Bold, 16pt
+    
+    /// For iOS below 26.0: bold, 16
     public static var h3 = UIFont.systemFont(ofSize: 16.0, weight: .bold)
     
     // MARK: - Body

--- a/Sources/Theme/SBUTheme.swift
+++ b/Sources/Theme/SBUTheme.swift
@@ -411,6 +411,9 @@ public class SBUGroupChannelListTheme {
         theme.leaveTintColor = SBUColorSet.onDarkTextHighEmphasis
         
         theme.alertBackgroundColor = SBUColorSet.background50
+        theme.channelTypeSelectorItemTintColor = SBUColorSet.primaryMain
+        
+        theme.navigationBarGradientTint = SBUColorSet.background50
         
         return theme
     }
@@ -435,23 +438,30 @@ public class SBUGroupChannelListTheme {
         theme.leaveTintColor = SBUColorSet.onLightTextHighEmphasis
         
         theme.alertBackgroundColor = SBUColorSet.background600
+        theme.channelTypeSelectorItemTintColor = SBUColorSet.primaryLight
+        
+        theme.navigationBarGradientTint = SBUColorSet.background600
         
         return theme
     }
     
-    public init(statusBarStyle: UIStatusBarStyle = .default,
-                leftBarButtonTintColor: UIColor = SBUColorSet.primaryMain,
-                rightBarButtonTintColor: UIColor = SBUColorSet.primaryMain,
-                navigationBarTintColor: UIColor = SBUColorSet.background50,
-                navigationBarShadowColor: UIColor = SBUColorSet.onLightTextDisabled,
-                backgroundColor: UIColor = SBUColorSet.background50,
-                notificationOnBackgroundColor: UIColor = SBUColorSet.primaryMain,
-                notificationOnTintColor: UIColor = SBUColorSet.onDarkTextHighEmphasis,
-                notificationOffBackgroundColor: UIColor = SBUColorSet.background200,
-                notificationOffTintColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
-                leaveBackgroundColor: UIColor = SBUColorSet.errorMain,
-                leaveTintColor: UIColor = SBUColorSet.onDarkTextHighEmphasis,
-                alertBackgroundColor: UIColor = SBUColorSet.background50) {
+    public init(
+        statusBarStyle: UIStatusBarStyle = .default,
+        leftBarButtonTintColor: UIColor = SBUColorSet.primaryMain,
+        rightBarButtonTintColor: UIColor = SBUColorSet.primaryMain,
+        navigationBarTintColor: UIColor = SBUColorSet.background50,
+        navigationBarShadowColor: UIColor = SBUColorSet.onLightTextDisabled,
+        backgroundColor: UIColor = SBUColorSet.background50,
+        notificationOnBackgroundColor: UIColor = SBUColorSet.primaryMain,
+        notificationOnTintColor: UIColor = SBUColorSet.onDarkTextHighEmphasis,
+        notificationOffBackgroundColor: UIColor = SBUColorSet.background200,
+        notificationOffTintColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
+        leaveBackgroundColor: UIColor = SBUColorSet.errorMain,
+        leaveTintColor: UIColor = SBUColorSet.onDarkTextHighEmphasis,
+        alertBackgroundColor: UIColor = SBUColorSet.background50,
+        channelTypeSelectorItemTintColor: UIColor = SBUColorSet.primaryMain,
+        navigationBarGradientTint: UIColor = SBUColorSet.background50
+    ) {
         
         self.statusBarStyle = statusBarStyle
         self.leftBarButtonTintColor = leftBarButtonTintColor
@@ -466,7 +476,8 @@ public class SBUGroupChannelListTheme {
         self.leaveBackgroundColor = leaveBackgroundColor
         self.leaveTintColor = leaveTintColor
         self.alertBackgroundColor = alertBackgroundColor
-        
+        self.channelTypeSelectorItemTintColor = channelTypeSelectorItemTintColor
+        self.navigationBarGradientTint = navigationBarGradientTint
     }
     
     public var statusBarStyle: UIStatusBarStyle
@@ -487,6 +498,12 @@ public class SBUGroupChannelListTheme {
     public var leaveTintColor: UIColor
     
     public var alertBackgroundColor: UIColor
+    
+    /// - Since: 3.34.0
+    public var channelTypeSelectorItemTintColor: UIColor
+    
+    // Liquid Glass
+    public var navigationBarGradientTint: UIColor
 }
 
 // MARK: - Group Channel Cell Theme
@@ -669,6 +686,8 @@ public class SBUOpenChannelListTheme {
         theme.refreshIndicatorColor = SBUColorSet.primaryMain
         theme.refreshBackgroundColor = SBUColorSet.background100
         
+        theme.navigationBarGradientTint = SBUColorSet.background50
+        
         return theme
     }
     
@@ -687,17 +706,21 @@ public class SBUOpenChannelListTheme {
         theme.refreshIndicatorColor = SBUColorSet.primaryLight
         theme.refreshBackgroundColor = SBUColorSet.background700
         
+        theme.navigationBarGradientTint = SBUColorSet.background600
         return theme
     }
     
-    public init(statusBarStyle: UIStatusBarStyle = .default,
-                leftBarButtonTintColor: UIColor = SBUColorSet.primaryMain,
-                rightBarButtonTintColor: UIColor = SBUColorSet.primaryMain,
-                navigationBarTintColor: UIColor = SBUColorSet.background50,
-                navigationBarShadowColor: UIColor = SBUColorSet.onLightTextDisabled,
-                backgroundColor: UIColor = SBUColorSet.background50,
-                refreshIndicatorColor: UIColor = SBUColorSet.primaryMain,
-                refreshBackgroundColor: UIColor = SBUColorSet.background100) {
+    public init(
+        statusBarStyle: UIStatusBarStyle = .default,
+        leftBarButtonTintColor: UIColor = SBUColorSet.primaryMain,
+        rightBarButtonTintColor: UIColor = SBUColorSet.primaryMain,
+        navigationBarTintColor: UIColor = SBUColorSet.background50,
+        navigationBarShadowColor: UIColor = SBUColorSet.onLightTextDisabled,
+        backgroundColor: UIColor = SBUColorSet.background50,
+        refreshIndicatorColor: UIColor = SBUColorSet.primaryMain,
+        refreshBackgroundColor: UIColor = SBUColorSet.background100,
+        navigationBarGradientTint: UIColor = SBUColorSet.background50
+    ) {
         
         self.statusBarStyle = statusBarStyle
         self.leftBarButtonTintColor = leftBarButtonTintColor
@@ -707,6 +730,7 @@ public class SBUOpenChannelListTheme {
         self.backgroundColor = backgroundColor
         self.refreshIndicatorColor = refreshIndicatorColor
         self.refreshBackgroundColor = refreshBackgroundColor
+        self.navigationBarGradientTint = navigationBarGradientTint
     }
     
     public var statusBarStyle: UIStatusBarStyle
@@ -720,6 +744,10 @@ public class SBUOpenChannelListTheme {
     
     public var refreshIndicatorColor: UIColor
     public var refreshBackgroundColor: UIColor
+    
+    // Liquid Glass
+    /// - Since: 3.34.0
+    public var navigationBarGradientTint: UIColor
 }
 
 // MARK: - Open Channel Cell Theme
@@ -856,6 +884,8 @@ public class SBUChannelTheme {
         theme.messageThreadTitleChannelNameColor = SBUColorSet.primaryMain
         theme.messageThreadTitleChannelNameFont = SBUFontSet.caption2
         
+        // Liquid glass
+        theme.navigationBarGradientTint = SBUColorSet.background50
         return theme
     }
     
@@ -900,6 +930,8 @@ public class SBUChannelTheme {
         theme.messageThreadTitleChannelNameColor = SBUColorSet.primaryLight
         theme.messageThreadTitleChannelNameFont = SBUFontSet.caption2
         
+        // Liquid glass
+        theme.navigationBarGradientTint = SBUColorSet.background600
         return theme
     }
     
@@ -944,6 +976,9 @@ public class SBUChannelTheme {
         theme.messageThreadTitleChannelNameColor = SBUColorSet.primaryLight
         theme.messageThreadTitleChannelNameFont = SBUFontSet.caption2
         
+        // Liquid glass
+        theme.navigationBarGradientTint = SBUColorSet.background600
+        
         return theme
     }
     
@@ -970,7 +1005,8 @@ public class SBUChannelTheme {
                 messageThreadTitleColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
                 messageThreadTitleFont: UIFont = SBUFontSet.h3,
                 messageThreadTitleChannelNameColor: UIColor = SBUColorSet.primaryMain,
-                messageThreadTitleChannelNameFont: UIFont = SBUFontSet.caption2
+                messageThreadTitleChannelNameFont: UIFont = SBUFontSet.caption2,
+                navigationBarGradientTint: UIColor = SBUColorSet.background50
     ) {
         
         self.statusBarStyle = statusBarStyle
@@ -999,6 +1035,9 @@ public class SBUChannelTheme {
         self.messageThreadTitleFont = messageThreadTitleFont
         self.messageThreadTitleChannelNameColor = messageThreadTitleChannelNameColor
         self.messageThreadTitleChannelNameFont = messageThreadTitleChannelNameFont
+        
+        // Liquid glass
+        self.navigationBarGradientTint = navigationBarGradientTint
     }
     
     public var statusBarStyle: UIStatusBarStyle
@@ -1008,6 +1047,7 @@ public class SBUChannelTheme {
     public var leftBarButtonTintColor: UIColor
     public var rightBarButtonTintColor: UIColor
     public var backgroundColor: UIColor
+    public var navigationBarGradientTint: UIColor
     
     // Alert
     public var removeItemColor: UIColor
@@ -1064,6 +1104,28 @@ public class SBUMessageInputTheme {
         theme.saveButtonFont = SBUFontSet.button2
         theme.saveButtonTextColor = SBUColorSet.onDarkTextHighEmphasis
         
+        // Liquid glass - Adaptive
+        theme._backgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background50,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._textFieldBackgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background100,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._textFieldBorderColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background100,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._channelViewDividerColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.onLightTextDisabled,
+            liquidGlass: SBUColorSet.background0
+        )
+        
+        // Liquid glass only
+        theme.inputViewShadowColor = SBUColorSet.background700
+        theme.inputButtonBackgroundColor = SBUColorSet.liquidGlassInputButtonBackgroundLight
+        
         // Quoted message
         theme.channelViewDividerColor = SBUColorSet.onLightTextDisabled
         theme.quotedFileMessageThumbnailBackgroundColor = SBUColorSet.background200
@@ -1099,6 +1161,29 @@ public class SBUMessageInputTheme {
         theme.saveButtonFont = SBUFontSet.button2
         theme.saveButtonTextColor = SBUColorSet.onLightTextHighEmphasis
         
+        // Liquid glass - Adaptive
+        theme._backgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background600,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._textFieldBackgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background600,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._textFieldBorderColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background400,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._channelViewDividerColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.onDarkTextDisabled,
+            liquidGlass: SBUColorSet.background0
+        )
+        
+        // Liquid glass only
+        theme.inputViewShadowColor = SBUColorSet.background700
+        theme.inputButtonBackgroundColor = SBUColorSet.liquidGlassInputButtonBackgroundDark
+        
+        // Quoted message
         theme.channelViewDividerColor = SBUColorSet.onDarkTextDisabled
         theme.quotedFileMessageThumbnailBackgroundColor = SBUColorSet.background500
         theme.quotedFileMessageThumbnailTintColor = SBUColorSet.onDarkTextMidEmphasis
@@ -1137,36 +1222,68 @@ public class SBUMessageInputTheme {
         theme.mentionTextColor = SBUColorSet.onDarkTextHighEmphasis
         theme.mentionTextBackgroundColor = .clear
         
+        // Liquid glass - adaptive
+        theme._backgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.onLightTextMidEmphasis,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._textFieldBackgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background400,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._textFieldBorderColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background400,
+            liquidGlass: SBUColorSet.background0
+        )
+        theme._channelViewDividerColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.onLightTextDisabled,
+            liquidGlass: SBUColorSet.background0
+        )
+        
+        // Liquid glass only
+        theme.inputViewShadowColor = SBUColorSet.background700
+        theme.inputButtonBackgroundColor = SBUColorSet.liquidGlassInputButtonBackgroundLight
+        
         return theme
     }
 
     // swiftlint:disable identifier_name
-    public init(backgroundColor: UIColor = SBUColorSet.background50,
-                textFieldBackgroundColor: UIColor = SBUColorSet.background100,
-                textFieldPlaceholderColor: UIColor = SBUColorSet.onLightTextLowEmphasis,
-                textFieldPlaceholderFont: UIFont = SBUFontSet.body3,
-                textFieldDisabledColor: UIColor = SBUColorSet.onLightTextDisabled,
-                textFieldTintColor: UIColor = SBUColorSet.primaryMain,
-                textFieldTextColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
-                textFieldBorderColor: UIColor = SBUColorSet.background100,
-                textFieldFont: UIFont = SBUFontSet.body3,
-                buttonTintColor: UIColor = SBUColorSet.primaryMain,
-                buttonDisabledTintColor: UIColor = SBUColorSet.onLightTextDisabled,
-                cancelButtonFont: UIFont = SBUFontSet.button2,
-                saveButtonFont: UIFont = SBUFontSet.button2,
-                saveButtonTextColor: UIColor = SBUColorSet.onDarkTextHighEmphasis,
-                channelViewDividerColor: UIColor = SBUColorSet.onLightTextDisabled,
-                quotedFileMessageThumbnailBackgroundColor: UIColor = SBUColorSet.background200,
-                quotedFileMessageThumbnailTintColor: UIColor = SBUColorSet.onLightTextMidEmphasis,
-                replyToTextColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
-                replyToTextFont: UIFont = SBUFontSet.caption1,
-                quotedMessageTextColor: UIColor = SBUColorSet.onLightTextLowEmphasis,
-                quotedMessageTextFont: UIFont = SBUFontSet.caption2,
-                closeReplyButtonColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
-                mentionTextFont: UIFont = SBUFontSet.body2,
-                mentionTextColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
-                mentionTextBackgroundColor: UIColor = .clear
-                
+    public init(
+        backgroundColor: UIColor = SBUColorSet.background50,
+        textFieldBackgroundColor: UIColor = SBUColorSet.background100,
+        textFieldPlaceholderColor: UIColor = SBUColorSet.onLightTextLowEmphasis,
+        textFieldPlaceholderFont: UIFont = SBUFontSet.body3,
+        textFieldDisabledColor: UIColor = SBUColorSet.onLightTextDisabled,
+        textFieldTintColor: UIColor = SBUColorSet.primaryMain,
+        textFieldTextColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
+        textFieldBorderColor: UIColor = SBUColorSet.background100,
+        textFieldFont: UIFont = SBUFontSet.body3,
+        buttonTintColor: UIColor = SBUColorSet.primaryMain,
+        buttonDisabledTintColor: UIColor = SBUColorSet.onLightTextDisabled,
+        cancelButtonFont: UIFont = SBUFontSet.button2,
+        saveButtonFont: UIFont = SBUFontSet.button2,
+        saveButtonTextColor: UIColor = SBUColorSet.onDarkTextHighEmphasis,
+        channelViewDividerColor: UIColor = SBUColorSet.onLightTextDisabled,
+        quotedFileMessageThumbnailBackgroundColor: UIColor = SBUColorSet.background200,
+        quotedFileMessageThumbnailTintColor: UIColor = SBUColorSet.onLightTextMidEmphasis,
+        replyToTextColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
+        replyToTextFont: UIFont = SBUFontSet.caption1,
+        quotedMessageTextColor: UIColor = SBUColorSet.onLightTextLowEmphasis,
+        quotedMessageTextFont: UIFont = SBUFontSet.caption2,
+        closeReplyButtonColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
+        mentionTextFont: UIFont = SBUFontSet.body2,
+        mentionTextColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
+        mentionTextBackgroundColor: UIColor = .clear,
+        
+        // Liquid glass - Adaptive
+        backgroundColorLiquidGlass: UIColor = .clear,
+        textFieldBackgroundColorLiquidGlass: UIColor = .clear,
+        textFieldBorderColorLiquidGlass: UIColor = .clear,
+        channelViewDividerColorLiquidGlass: UIColor = .clear,
+        
+        // Liquid glass only
+        inputViewShadowColor: UIColor = SBUColorSet.background700,
+        inputButtonBackgroundColor: UIColor = SBUColorSet.background700
     ) {
         
         self.backgroundColor = backgroundColor
@@ -1184,6 +1301,28 @@ public class SBUMessageInputTheme {
         self.saveButtonFont = saveButtonFont
         self.saveButtonTextColor = saveButtonTextColor
         
+        // Liquid glass - Adaptive
+        self._backgroundColorAdaptive = SBUAdaptive(
+            base: backgroundColor,
+            liquidGlass: backgroundColorLiquidGlass
+        )
+        self._textFieldBackgroundColorAdaptive = SBUAdaptive(
+            base: textFieldBackgroundColor,
+            liquidGlass: textFieldBackgroundColorLiquidGlass
+        )
+        self._textFieldBorderColorAdaptive = SBUAdaptive(
+            base: textFieldBorderColor,
+            liquidGlass: textFieldBorderColorLiquidGlass
+        )
+        self._channelViewDividerColorAdaptive = SBUAdaptive(
+            base: channelViewDividerColor,
+            liquidGlass: channelViewDividerColorLiquidGlass
+        )
+        
+        // Liquid glass only
+        self.inputViewShadowColor = inputViewShadowColor
+        self.inputButtonBackgroundColor = inputButtonBackgroundColor
+        
         // Quoted message
         self.channelViewDividerColor = channelViewDividerColor
         self.quotedFileMessageThumbnailBackgroundColor = quotedFileMessageThumbnailBackgroundColor
@@ -1199,14 +1338,41 @@ public class SBUMessageInputTheme {
     }
     // swiftlint:enable identifier_name
     
-    public var backgroundColor: UIColor
-    public var textFieldBackgroundColor: UIColor
+    @available(*, deprecated, renamed: "backgroundColorAdaptive")
+    public var backgroundColor: UIColor {
+        didSet {
+            self._backgroundColorAdaptive = SBUAdaptive(
+                base: backgroundColor,
+                liquidGlass: backgroundColor
+            )
+        }
+    }
+    
+    @available(*, deprecated, renamed: "textFieldBackgroundColorAdaptive")
+    public var textFieldBackgroundColor: UIColor {
+        didSet {
+            self._textFieldBackgroundColorAdaptive = SBUAdaptive(
+                base: textFieldBackgroundColor,
+                liquidGlass: textFieldBackgroundColor
+            )
+        }
+    }
     public var textFieldPlaceholderColor: UIColor
     public var textFieldPlaceholderFont: UIFont
     public var textFieldDisabledColor: UIColor
     public var textFieldTintColor: UIColor
     public var textFieldTextColor: UIColor
-    public var textFieldBorderColor: UIColor
+    
+    @available(*, deprecated, renamed: "textFieldBorderColorAdaptive")
+    public var textFieldBorderColor: UIColor {
+        didSet {
+            self._textFieldBorderColorAdaptive = SBUAdaptive(
+                base: textFieldBorderColor,
+                liquidGlass: textFieldBorderColor
+            )
+        }
+    }
+    
     public var textFieldFont: UIFont
     
     public var buttonTintColor: UIColor
@@ -1216,8 +1382,27 @@ public class SBUMessageInputTheme {
     public var saveButtonFont: UIFont
     public var saveButtonTextColor: UIColor
     
+    // MARK: Liquid glass
+    /// - Since: 3.34.0
+    @SBUAdaptive public var backgroundColorAdaptive: UIColor
+    /// - Since: 3.34.0
+    @SBUAdaptive public var textFieldBackgroundColorAdaptive: UIColor
+    /// - Since: 3.34.0
+    @SBUAdaptive public var textFieldBorderColorAdaptive: UIColor
+    /// - Since: 3.34.0
+    @SBUAdaptive public var channelViewDividerColorAdaptive: UIColor
+    
+    /// The color of shadow behind the message input view when liquid glass is enabled.
+    /// - Since: 3.34.0
+    public var inputViewShadowColor: UIColor
+    
+    /// The background color of a button in the message input view when liquid glass is enabled.
+    /// - Since: 3.34.0
+    public var inputButtonBackgroundColor: UIColor
+    
     // MARK: Quoted message
     /// The color of divider between message input view and table view of channel view.
+    @available(*, deprecated, renamed: "channelViewDividerColorAdaptive")
     public var channelViewDividerColor: UIColor
     
     // swiftlint:disable identifier_name
@@ -2938,6 +3123,25 @@ public class SBUComponentTheme {
         theme.shadowColor = SBUColorSet.background700.withAlphaComponent(0.12)
         theme.closeBarButtonTintColor = SBUColorSet.onLightTextHighEmphasis
         
+        // Common > Liquid glass (3.34.0)
+        theme._backgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background50,
+            liquidGlass: SBUColorSet.background0
+        )
+        
+        theme._alertButtonBackgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background50,
+            liquidGlass: SBUColorSet.buttonBackgroundLight
+        )
+        theme._highlightedColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background100,
+            liquidGlass: SBUColorSet.liquidGlassButtonHighlightLight
+        )
+        theme._overlayColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.overlayDark,
+            liquidGlass: SBUColorSet.overlayDarkLiquidGlass
+        )
+        
         // Alert
         theme.alertTitleColor = SBUColorSet.onLightTextHighEmphasis
         theme.alertTitleFont = SBUFontSet.h3
@@ -2950,6 +3154,12 @@ public class SBUComponentTheme {
         theme.alertTextFieldBackgroundColor = SBUColorSet.background100
         theme.alertTextFieldTintColor = SBUColorSet.primaryMain
         theme.alertTextFieldFont = SBUFontSet.body3
+        
+        // Alert > Liquid glass (3.34.0)
+        theme._alertTitleFontAdaptive = SBUAdaptive(
+            base: SBUFontSet.h3,
+            liquidGlass: SBUFontSet.h1
+        )
         
         // Action Sheet
         theme.actionSheetTextFont = SBUFontSet.subtitle1
@@ -3044,6 +3254,12 @@ public class SBUComponentTheme {
         theme.newLineLabelTintColor = SBUColorSet.primaryMain
         theme.newLineTintColor = SBUColorSet.primaryMain
         
+        // Liquid glass
+        theme._shadowColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background700.withAlphaComponent(0.12),
+            liquidGlass: SBUColorSet.liquidGlassMenuViewShadowLight
+        )
+        
         return theme
     }
     
@@ -3063,7 +3279,7 @@ public class SBUComponentTheme {
         theme.highlightedColor = SBUColorSet.background400
         theme.buttonTextColor = SBUColorSet.primaryLight
         theme.separatorColor = SBUColorSet.onDarkTextDisabled
-        theme.shadowColor = SBUColorSet.background700.withAlphaComponent(0.36)
+        theme.shadowColor = SBUColorSet.liquidGlassMenuViewShadowDark
         theme.closeBarButtonTintColor = SBUColorSet.onDarkTextHighEmphasis
         
         // Alert
@@ -3172,6 +3388,31 @@ public class SBUComponentTheme {
         theme.newLineLabelTintColor = SBUColorSet.primaryLight
         theme.newLineTintColor = SBUColorSet.primaryLight
         
+        // Liquid glass 3.34.0
+        theme._backgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background500,
+            liquidGlass: SBUColorSet.background0
+        )
+        
+        theme._alertButtonBackgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background500,
+            liquidGlass: SBUColorSet.buttonBackgroundDark
+        )
+        
+        theme._highlightedColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background100,
+            liquidGlass: SBUColorSet.liquidGlassButtonHighlightDark
+        )
+        
+        theme._shadowColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background700.withAlphaComponent(0.12),
+            liquidGlass: SBUColorSet.liquidGlassMenuViewShadowLight
+        )
+        theme._overlayColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.overlayLight,
+            liquidGlass: SBUColorSet.overlayLight
+        )
+        
         return theme
     }
     
@@ -3191,7 +3432,7 @@ public class SBUComponentTheme {
         theme.highlightedColor = SBUColorSet.background400
         theme.buttonTextColor = SBUColorSet.primaryLight
         theme.separatorColor = SBUColorSet.onDarkTextDisabled
-        theme.shadowColor = SBUColorSet.background700.withAlphaComponent(0.36)
+        theme.shadowColor = SBUColorSet.liquidGlassMenuViewShadowLight
         theme.closeBarButtonTintColor = SBUColorSet.onDarkTextHighEmphasis
         
         // Alert
@@ -3289,6 +3530,22 @@ public class SBUComponentTheme {
         
         theme.feedbackToastUpdateDoneColor = SBUColorSet.secondaryLight // 3.15.0
         
+        // Liquid glass  3.34.0
+        theme._shadowColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.background700.withAlphaComponent(0.12),
+            liquidGlass: SBUColorSet.liquidGlassMenuViewShadowLight
+        )
+
+        theme._backgroundColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.onLightTextLowEmphasis,
+            liquidGlass: SBUColorSet.onLightTextLowEmphasis
+        )
+        
+        theme._overlayColorAdaptive = SBUAdaptive(
+            base: SBUColorSet.overlayDark,
+            liquidGlass: SBUColorSet.overlayDarkLiquidGlass
+        )
+        
         return theme
     }
     
@@ -3306,6 +3563,7 @@ public class SBUComponentTheme {
                 closeBarButtonTintColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
                 alertTitleColor: UIColor = SBUColorSet.onLightTextHighEmphasis,
                 alertTitleFont: UIFont = SBUFontSet.h3,
+                alertTitleLiquidGlassFont: UIFont = SBUFontSet.h1,
                 alertDetailColor: UIColor = SBUColorSet.onLightTextMidEmphasis,
                 alertDetailFont: UIFont = SBUFontSet.body3,
                 alertPlaceholderColor: UIColor = SBUColorSet.onLightTextLowEmphasis,
@@ -3378,7 +3636,13 @@ public class SBUComponentTheme {
                 
                 newLineLabelFont: UIFont = SBUFontSet.caption3,
                 newLineLabelTintColor: UIColor = SBUColorSet.primaryMain,
-                newLineTintColor: UIColor = SBUColorSet.primaryMain
+                newLineTintColor: UIColor = SBUColorSet.primaryMain,
+                
+                backgroundLiquidGlassColor: UIColor = SBUColorSet.background0,
+                buttonBackgroundLiquidGlassColor: UIColor = SBUColorSet.background0,
+                highlightedLiquidGlassColor: UIColor = SBUColorSet.liquidGlassButtonHighlightLight,
+                shadowColorLiquidGlass: UIColor = SBUColorSet.liquidGlassMenuViewShadowLight,
+                overlayColorLiquidGlass: UIColor = SBUColorSet.overlayDarkLiquidGlass
     ) {
         
         self.emptyViewBackgroundColor = emptyViewBackgroundColor
@@ -3482,6 +3746,33 @@ public class SBUComponentTheme {
         self.newLineLabelFont = newLineLabelFont
         self.newLineLabelTintColor = newLineLabelTintColor
         self.newLineTintColor = newLineTintColor
+        
+        // Liquid glass 3.34.0
+        self._backgroundColorAdaptive = SBUAdaptive(
+            base: backgroundColor,
+            liquidGlass: backgroundLiquidGlassColor
+        )
+        
+        self._alertButtonBackgroundColorAdaptive = SBUAdaptive(
+            base: backgroundColor,
+            liquidGlass: buttonBackgroundLiquidGlassColor
+        )
+        
+        self._highlightedColorAdaptive = SBUAdaptive(
+            base: highlightedColor,
+            liquidGlass: highlightedLiquidGlassColor
+        )
+        
+        self._alertTitleFontAdaptive = SBUAdaptive(
+            base: alertTitleFont,
+            liquidGlass: alertTitleLiquidGlassFont
+        )
+        
+        self._shadowColorAdaptive = SBUAdaptive(base: shadowColor, liquidGlass: shadowColorLiquidGlass)
+        self._overlayColorAdaptive = SBUAdaptive(
+            base: overlayColor,
+            liquidGlass: overlayColorLiquidGlass
+        )
     }
     
     // EmptyView
@@ -3503,6 +3794,14 @@ public class SBUComponentTheme {
     public var alertTextFieldBackgroundColor: UIColor
     public var alertTextFieldTintColor: UIColor
     public var alertTextFieldFont: UIFont
+    
+    // Alert - Liquid Glass
+    // 3.34.0
+    @SBUAdaptive public var backgroundColorAdaptive: UIColor
+    @SBUAdaptive public var alertButtonBackgroundColorAdaptive: UIColor
+    @SBUAdaptive public var highlightedColorAdaptive: UIColor
+    @SBUAdaptive public var alertTitleFontAdaptive: UIFont
+    @SBUAdaptive public var overlayColorAdaptive: UIColor
     
     // Action Sheet
     public var actionSheetTextFont: UIFont
@@ -3540,11 +3839,28 @@ public class SBUComponentTheme {
     
     // Common
     public var overlayColor: UIColor
-    public var backgroundColor: UIColor
-    public var highlightedColor: UIColor
+    @available(*, deprecated, renamed: "backgroundAdaptiveColor")
+    public var backgroundColor: UIColor {
+        // 3.34.0
+        didSet {
+            self._backgroundColorAdaptive = SBUAdaptive(base: backgroundColor, liquidGlass: backgroundColor)
+        }
+    }
+    public var highlightedColor: UIColor {
+        // 3.34.0
+        didSet {
+            self._highlightedColorAdaptive = SBUAdaptive(base: highlightedColor, liquidGlass: highlightedColor)
+        }
+    }
     public var buttonTextColor: UIColor
     public var separatorColor: UIColor
-    public var shadowColor: UIColor
+    
+    public var shadowColor: UIColor {
+        didSet {
+            self._shadowColorAdaptive = SBUAdaptive(base: shadowColor, liquidGlass: shadowColor)
+        }
+    }
+    
     public var closeBarButtonTintColor: UIColor
     
     // placeholder
@@ -3611,6 +3927,10 @@ public class SBUComponentTheme {
     public var newLineLabelFont: UIFont  // 3.32.0
     public var newLineLabelTintColor: UIColor  // 3.32.0
     public var newLineTintColor: UIColor  // 3.32.0
+    
+    // Liquid Glass
+    /// - Since: 3.34.0
+    @SBUAdaptive public var shadowColorAdaptive: UIColor
 }
 
 // MARK: - Message Search Theme

--- a/Sources/Util/SBULiquidGlassUtils.swift
+++ b/Sources/Util/SBULiquidGlassUtils.swift
@@ -1,0 +1,74 @@
+//
+//  SBULiquidGlassUtils.swift
+//  SendbirdUIKit
+//
+//  Created by Celine Moon on 1/20/26.
+//
+
+import UIKit
+
+/// Utility for creating liquid glass effect views (iOS 26+)
+/// - Since: 3.34.0
+public enum SBULiquidGlassUtils {
+
+    /// Creates a UIVisualEffectView with glass effect for iOS 26+
+    /// - Parameter isInteractive: Whether the glass effect should be interactive. Default is `false`.
+    /// - Returns: A UIVisualEffectView with glass effect, or `nil` if not available or not in liquid glass mode.
+    public static func createGlassEffectView(
+        isInteractive: Bool = false
+    ) -> UIVisualEffectView? {
+        guard SendbirdUI.config.common.shouldApplyLiquidGlass else { return nil }
+
+        #if compiler(>=6.2)
+        guard #available(iOS 26.0, *) else { return nil }
+
+        let glassEffect = UIGlassEffect()
+        glassEffect.isInteractive = isInteractive
+
+        return UIVisualEffectView(effect: glassEffect)
+        #else
+        return nil
+        #endif
+    }
+    
+    /// Util function that creates a glass effect view, and also sets up layout and style. 
+    public static func createAndSetupGlassEffectView(
+        isInteractive: Bool = false,
+        // layout
+        frame: CGRect?,
+        autoresizingMask: UIView.AutoresizingMask?,
+        // style
+        cornerRadius: CGFloat?,
+        cornerCurve: CALayerCornerCurve?,
+        clipsToBounds: Bool?
+    ) -> UIVisualEffectView? {
+        guard SendbirdUI.config.common.shouldApplyLiquidGlass else { return nil }
+
+        #if compiler(>=6.2)
+        guard #available(iOS 26.0, *) else { return nil }
+
+        let glassEffect = UIGlassEffect()
+        glassEffect.isInteractive = isInteractive
+
+        let glassEffectView = UIVisualEffectView(effect: glassEffect)
+        
+        // layout
+        glassEffectView.setupLayouts(
+            frame: frame,
+            autoresizingMask: autoresizingMask
+        )
+        
+        // style
+        glassEffectView.setupStyles(
+            cornerRadius: cornerRadius,
+            cornerCurve: cornerCurve,
+            clipsToBounds: clipsToBounds
+        )
+        
+        return glassEffectView
+        
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/Util/SBUPropertyWrapper.swift
+++ b/Sources/Util/SBUPropertyWrapper.swift
@@ -138,3 +138,102 @@ public struct SBUPrioritizedConfig<T>: Codable where T: Codable {
         try container.encode(self.value)
     }
 }
+
+// MARK: - Liquid Glass
+
+/// `SBUAdaptive` is a generic property wrapper that provides different values
+/// depending on whether liquid glass mode is enabled.
+///
+/// When `SendbirdUI.config.common.shouldApplyLiquidGlass` is `true`, returns `liquidGlassValue`.
+/// Otherwise, returns `baseValue`.
+///
+/// This wrapper only accepts types conforming to ``SBUAdaptiveCompatible``.
+/// Currently supported types: `UIColor`, `UIFont`, `CGFloat`.
+///
+/// **Usage:**
+/// ```swift
+/// @SBUAdaptive
+/// public var backgroundColor: UIColor
+///
+/// @SBUAdaptive
+/// public var titleFont: UIFont
+///
+/// @SBUAdaptive
+/// public var cornerRadius: CGFloat
+///
+/// // In init:
+/// self._backgroundColor = SBUAdaptive(
+///     base: SBUColorSet.background50,
+///     liquidGlass: .clear
+/// )
+///
+/// // Access (returns appropriate value based on liquid glass mode):
+/// view.backgroundColor = theme.backgroundColor
+/// ```
+///
+/// - Since: 3.34.0
+@propertyWrapper
+public struct SBUAdaptive<T: SBUAdaptiveCompatible> {
+    /// The value used when liquid glass mode is disabled (default mode).
+    private var baseValue: T
+
+    /// The value used when liquid glass mode is enabled.
+    private var liquidGlassValue: T
+
+    /// Returns the appropriate value based on the current liquid glass mode setting.
+    /// - Returns: `liquidGlassValue` if liquid glass mode is enabled, otherwise `baseValue`.
+    public var wrappedValue: T {
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            return liquidGlassValue
+        } else {
+            return baseValue
+        }
+    }
+
+    /// Provides access to the wrapper itself for calling mutating methods.
+    /// Use the `$` prefix to access this value (e.g., `$backgroundColor`).
+    public var projectedValue: Self {
+        get { self }
+        set { self = newValue }
+    }
+
+    /// Initializes the adaptive value with separate values for each mode.
+    /// - Parameters:
+    ///   - base: The value to use when liquid glass mode is disabled.
+    ///   - liquidGlass: The value to use when liquid glass mode is enabled.
+    public init(base: T, liquidGlass: T) {
+        self.baseValue = base
+        self.liquidGlassValue = liquidGlass
+    }
+
+    /// Updates one or both values.
+    /// - Parameters:
+    ///   - base: The new base value. If `nil`, the current base value is unchanged.
+    ///   - liquidGlass: The new liquid glass value. If `nil`, the current liquid glass value is unchanged.
+    public mutating func updateValues(base: T? = nil, liquidGlass: T? = nil) {
+        if let base {
+            baseValue = base
+        }
+        if let liquidGlass {
+            liquidGlassValue = liquidGlass
+        }
+    }
+}
+
+/// A marker protocol that restricts which types can be used with ``SBUAdaptive``.
+///
+/// Only types conforming to this protocol can be wrapped by `SBUAdaptive`.
+/// This ensures type safety and prevents misuse with incompatible types.
+///
+/// **Supported types:**
+/// - `UIColor` — For adaptive colors
+/// - `UIFont` — For adaptive fonts
+/// - `CGFloat` — For adaptive sizes and dimensions
+///
+/// - Since: 3.34.0
+public protocol SBUAdaptiveCompatible {}
+
+extension UIColor: SBUAdaptiveCompatible {}
+extension UIFont: SBUAdaptiveCompatible {}
+extension CGFloat: SBUAdaptiveCompatible {}
+extension CGSize: SBUAdaptiveCompatible {}

--- a/Sources/View/Channel/MessageInput/SBUMessageInputView.swift
+++ b/Sources/View/Channel/MessageInput/SBUMessageInputView.swift
@@ -151,13 +151,23 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     
     public lazy var textView: UITextView? = {
         let textView = UITextView()
-        textView.textContainerInset = UIEdgeInsets(top: 10, left: 9, bottom: 10, right: 16)
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            textView.textContainerInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+            // remove the default spacing between the UITextView box & starting text position
+            textView.textContainer.lineFragmentPadding = 0
+        } else {
+            textView.textContainerInset = UIEdgeInsets(top: 10, left: 9, bottom: 10, right: 16)
+            textView.layer.cornerRadius = 20
+        }
         textView.layer.borderWidth = 1
-        textView.layer.cornerRadius = 20
         textView.delegate = self
         return textView
     }()
-    
+
+    /// The glass effect view that wraps the text view for iOS 26+.
+    /// - Since: 3.34.0
+    public var glassEffectView: UIVisualEffectView?
+
     public lazy var sendButton: UIButton? = {
         let button = UIButton()
         button.layer.cornerRadius = 4
@@ -210,7 +220,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     public lazy var inputHStackView: UIStackView = {
         let stackView = SBUStackView(
             axis: .horizontal,
-            alignment: .bottom,
+            alignment: SendbirdUI.config.common.shouldApplyLiquidGlass ? .center : .bottom,
             spacing: 0
         )
         stackView.distribution = .fill
@@ -236,12 +246,49 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     
     // MARK: - Property values (Public)
     /// The leading spacing for message input view
-    public var leadingSpacing: CGFloat = 12
+    @available(*, deprecated, renamed: "leadingSpacingAdaptive")
+    public var leadingSpacing: CGFloat = 12 {
+        didSet {
+            self._leadingSpacingAdaptive = SBUAdaptive(
+                base: leadingSpacing,
+                liquidGlass: leadingSpacing
+            )
+        }
+    }
     /// The trailing spacing for message input view
-    public var trailingSpacing: CGFloat = 12
+    @available(*, deprecated, renamed: "trailingSpacingAdaptive")
+    public var trailingSpacing: CGFloat = 12 {
+        didSet {
+            self._trailingSpacingAdaptive = SBUAdaptive(
+                base: trailingSpacing,
+                liquidGlass: trailingSpacing
+            )
+        }
+    }
+    
+    /// - Since: 3.34.0
+    @SBUAdaptive(base: 12, liquidGlass: 8)
+    public var leadingSpacingAdaptive: CGFloat
+    
+    /// - Since: 3.34.0
+    @SBUAdaptive(base: 12, liquidGlass: 16)
+    public var trailingSpacingAdaptive: CGFloat
     
     /// Textview's minimum height value.
-    public var textViewMinHeight: CGFloat = 38
+    @available(*, deprecated, renamed: "textViewMinHeightAdaptive")
+    public var textViewMinHeight: CGFloat = 38 {
+        didSet {
+            self._textViewMinHeightAdaptive = SBUAdaptive(
+                base: textViewMinHeight,
+                liquidGlass: textViewMinHeight
+            )
+        }
+    }
+    
+    /// - Since: 3.34.0
+    @SBUAdaptive(base: 38, liquidGlass: 20)
+    public var textViewMinHeightAdaptive: CGFloat
+    
     /// Textview's maximum height value.
     public var textViewMaxHeight: CGFloat = 87
     /// Whether to always show the send button. Default is `false`.
@@ -252,10 +299,41 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     
     /// Leading spacing value for `textView`.
     /// If `addButton` is available, this will be spacing between the `addButton` and the `textView`.
-    public var textViewLeadingSpacing: CGFloat = 12
+    @available(*, deprecated, renamed: "textViewLeadingSpacingAdaptive")
+    public var textViewLeadingSpacing: CGFloat = 12 {
+        didSet {
+            self._textViewLeadingSpacingAdaptive = SBUAdaptive(
+                base: textViewLeadingSpacing,
+                liquidGlass: textViewLeadingSpacing
+            )
+        }
+    }
+    
     /// Trailing spacing value for `textView`.
     /// If `sendButton` or `voiceMessageButton` is available, this will be spacing between the `textView` and the `sendButton` or `voiceMessageButton`.
     public var textViewTrailingSpacing: CGFloat = 12
+    
+    /// - Since: 3.34.0
+    @SBUAdaptive(base: 12, liquidGlass: 8)
+    public var textViewLeadingSpacingAdaptive: CGFloat
+    
+    /// - Since: 3.34.0
+    @SBUAdaptive(
+        base: 32,
+        liquidGlass: SBUIconSetType.Metric.iconSizeLiquidGlass + 2*SBUIconSetType.Metric.iconPaddingLiquidGlass
+    )
+    public var buttonIconWidth
+    
+    /// - Since: 3.34.0
+    @SBUAdaptive(
+        base: 38,
+        liquidGlass: SBUIconSetType.Metric.iconSizeLiquidGlass + 2*SBUIconSetType.Metric.iconPaddingLiquidGlass
+    )
+    public var buttonIconHeight
+    
+    /// - Since: 3.34.0
+    @SBUAdaptive(base: 10, liquidGlass: 8)
+    public var inputVStackViewSpacing: CGFloat
     
     /// The padding values for the input view.
     /// This value will be relative to the `safeAreaLayoutGuide` if available.
@@ -322,9 +400,9 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         return SBUStackView(axis: .vertical, alignment: .fill, spacing: 0)
     }()
     
-    // + ------------------ + --------------- + ------------------ +
-    // | leadingPaddingView | inputVStackView | trailingPaddinView |
-    // + ------------------ + --------------- + ------------------ +
+    // + ------------------ + --------------- + ------------------- +
+    // | leadingPaddingView | inputVStackView | trailingPaddingView |
+    // + ------------------ + --------------- + ------------------- +
     
     lazy var contentHStackView: SBUStackView = {
         return SBUStackView(axis: .horizontal, alignment: .fill, spacing: 0)
@@ -341,14 +419,22 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     // + --------------------- +
     
     private lazy var inputVStackView: SBUStackView = {
-        let stackView = SBUStackView(axis: .vertical, alignment: .fill, spacing: 10)
+        let stackView = SBUStackView(
+            axis: .vertical,
+            alignment: .fill,
+            spacing: inputVStackViewSpacing
+        )
         stackView.distribution = .fill
         return stackView
     }()
     
     /// Space above the input fields.
     var inputViewTopSpacer = UIView()
-    
+
+    /// Height constraint for inputViewTopSpacer (used to adjust spacing in edit mode)
+    /// - Since: 3.34.0
+    var inputViewTopSpacerHeightConstraint: NSLayoutConstraint?
+
     /// Text view + placeholder label.
     var inputContentView = UIView()
     
@@ -430,6 +516,11 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     var channelType: SendbirdChatSDK.ChannelType {
         self.datasource?.channelForMessageInputView(self)?.channelType ?? .group
     }
+    
+    ///- Since: 3.34.0
+    private let iconSizeLiquidGlass: CGFloat = 22
+    ///- Since: 3.34.0
+    private let iconPaddingLiquidGlass: CGFloat = 3
     
     /// - Since: 1.1.0 (SendbirdSwiftUI)
     var isQuoteReplyingMode = false
@@ -551,41 +642,83 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         self.quoteMessageView?.isHidden = true
         self.divider.isHidden = true
         
-        // baseStackView
-        // + ---------------------------------------------------------------- +
-        // | divider                                                          |
-        // + ---------------------------------------------------------------- +
-        // | + ------------------------------------------------------------ + |
-        // | | quoteMessageView                                             | |
-        // | + ------------------------------------------------------------ + |
-        // + ------------------ + --------------------- + ------------------- +
-        // |                    | inputViewTopSpacer    |                     |
-        // |                    + --------------------- +                     |
-        // |                    | inputHStackView       |                     |
-        // | leadingPaddingView + --------------------- + trailingPaddingView |
-        // |                    | editView              |                     |
-        // |                    + --------------------- +                     |
-        // |                    | inputViewBottomSpacer |                     |
-        // + ------------------ + --------------------- + ------------------- +
-        
-        // inputHStackView
-        // + --------- + ------- + ---------------- + ------- + ---------- + ----------------- +
-        // | addButton | tvLP(*) | inputContentView | tvTP(*) | sendButton | voiceRecordButton |
-        // + --------- + ------- + ---------------- + ------- + ---------- + ----------------- +
+        // SBUMessageInputView (self)
+        // + ===================================================================== +
+        // |                                                                       |
+        // |  baseStackView (VStack)                                               |
+        // |  + ---------------------------------------------------------------- + |
+        // |  + glassEffectView (background, iOS 26+)                           + |
+        // |  + ---------------------------------------------------------------- + |
+        // |  | divider                                                          | |
+        // |  + ---------------------------------------------------------------- + |
+        // |  |                                                                  | |
+        // |  |  contentView                                                     | |
+        // |  |  + ----------------------------------------------------------- + | |
+        // |  |  |                                                             | | |
+        // |  |  |  contentVStackView (VStack)                                 | | |
+        // |  |  |  + ------------------------------------------------------ + | | |
+        // |  |  |  |                                                        | | | |
+        // |  |  |  |  topStackView (VStack)                                 | | | |
+        // |  |  |  |  + ------------------------------------------------- + | | | |
+        // |  |  |  |  | quoteMessageView                                  | | | | |
+        // |  |  |  |  + ------------------------------------------------- + | | | |
+        // |  |  |  |                                                        | | | |
+        // |  |  |  + ------------------------------------------------------ + | | |
+        // |  |  |  |                                                        | | | |
+        // |  |  |  |  contentHStackView (HStack)                            | | | |
+        // |  |  |  |  + ------------------------------------------------- + | | | |
+        // |  |  |  |  |                 |                   |             | | | | |
+        // |  |  |  |  |                 | inputVStackView   |             | | | | |
+        // |  |  |  |  |                 | (VStack)          |             | | | | |
+        // |  |  |  |  |                 | + ------------- + |             | | | | |
+        // |  |  |  |  |                 | |inputViewTop-  | |             | | | | |
+        // |  |  |  |  |                 | |Spacer         | |             | | | | |
+        // |  |  |  |  |                 | + ------------- + |             | | | | |
+        // |  |  |  |  | leadingPadding- | | inputHStack-  | | trailing-   | | | | |
+        // |  |  |  |  | View            | | View          | | PaddingView | | | | |
+        // |  |  |  |  |                 | + ------------- + |             | | | | |
+        // |  |  |  |  |                 | | editView      | |             | | | | |
+        // |  |  |  |  |                 | + ------------- + |             | | | | |
+        // |  |  |  |  |                 | |inputViewBottom| |             | | | | |
+        // |  |  |  |  |                 | |Spacer         | |             | | | | |
+        // |  |  |  |  |                 | + ------------- + |             | | | | |
+        // |  |  |  |  |                 |                   |             | | | | |
+        // |  |  |  |  + ------------------------------------------------- + | | | |
+        // |  |  |  |                                                        | | | |
+        // |  |  |  + ------------------------------------------------------ + | | |
+        // |  |  |                                                             | | |
+        // |  |  + ----------------------------------------------------------- + | |
+        // |  |                                                                  | |
+        // |  + ---------------------------------------------------------------- + |
+        // |                                                                       |
+        // + ===================================================================== +
+
+        // inputHStackView (HStack, alignment: .bottom)
+        // + --------- + ------- + ---------------- + ------- + ---------- + ------------------- +
+        // | addButton | tvLP(*) | inputContentView | tvTP(*) | sendButton | voiceMessageButton  |
+        // + --------- + ------- + ---------------- + ------- + ---------- + ------------------- +
         // * tvLP: textViewLeadingPaddingView
-        // * tvTP: textViewTrailingPaddinView
-        
+        // * tvTP: textViewTrailingPaddingView
+
+        // inputContentView
+        // + ----------------------------------------- +
+        // |  textView (fills)                         |
+        // |  + ------------------------------------ + |
+        // |  | placeholderLabel                     | |
+        // |  + ------------------------------------ + |
+        // + ----------------------------------------- +
+
         // editView
         // + ------------ + -------------- + ---------- +
         // | cancelButton | editMarginView | saveButton |
         // + ------------ + -------------- + ---------- +
         
-        // Add views
+        // Add views - textView and placeholder to inputContentView
         if let textView = self.textView {
             self.inputContentView.addSubview(textView)
             self.inputContentView.addSubview(self.placeholderLabel)
         }
-        
+
         self.editView.addSubview(
             self.editStackView.setHStack([
                 self.cancelButton,
@@ -593,7 +726,17 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
                 self.saveButton
             ])
         )
-        
+
+        // Setup inputHStackView
+        self.inputHStackView.setHStack([
+            self.addButton,
+            self.textViewLeadingPaddingView,
+            self.inputContentView,
+            self.textViewTrailingPaddingView,
+            self.sendButton,
+            self.voiceMessageButton,
+        ])
+
         self.contentView.addSubview(
             self.contentVStackView.setVStack([
                 self.topStackView.setVStack([
@@ -624,6 +767,13 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
             self.contentView
         ])
         
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            if let glassEffectView = SBULiquidGlassUtils.createGlassEffectView() {
+                self.baseStackView.insertSubview(glassEffectView, at: 0)
+                self.glassEffectView = glassEffectView
+            }
+        }
+        
         self.addSubview(self.baseStackView)
         
         #if SWIFTUI
@@ -647,37 +797,40 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
             .sbu_constraint(height: 32)
         
         // Subviews in InputVStackView
-        self.inputViewTopSpacer
-            .sbu_constraint(height: 0)
+        self.inputViewTopSpacerHeightConstraint = self.inputViewTopSpacer.heightAnchor.constraint(equalToConstant: 0)
+        self.inputViewTopSpacerHeightConstraint?.isActive = true
         
         self.inputViewBottomSpacer
             .sbu_constraint(height: 0)
         
         // Subviews in InputHStackView
         self.addButton?
-            .sbu_constraint(width: 32, height: 38)
+            .sbu_constraint(width: buttonIconWidth, height: buttonIconHeight)
         
         // leading/trailing spacing for textview
         self.textViewLeadingPaddingView
-            .sbu_constraint(width: self.textViewLeadingSpacing)
+            .sbu_constraint(width: self.textViewLeadingSpacingAdaptive)
         
         self.textViewTrailingPaddingView
             .sbu_constraint(width: self.textViewTrailingSpacing)
         
+        // sendButton
         self.sendButton?
-            .sbu_constraint(width: 32, height: 38)
-        
+            .sbu_constraint(width: buttonIconWidth, height: buttonIconHeight)
+
         self.voiceMessageButton?
-            .sbu_constraint(width: 32, height: 38)
+            .sbu_constraint(width: buttonIconWidth, height: buttonIconHeight)
         
-        // Subivews in InputContentView
+        // Subviews in InputContentView
         self.textView?
             .sbu_constraint(equalTo: self.inputContentView, leading: 0, trailing: 0, top: 0, bottom: 0)
-        
+
         if let textView = self.textView {
-            let leading: CGFloat = self.currentLayoutDirection.isRTL ? 22 : 14
+            let tempLeading: CGFloat = self.currentLayoutDirection.isRTL ? 22 : 14
+            let leading: CGFloat = SendbirdUI.config.common.shouldApplyLiquidGlass ? 0 : tempLeading
+            
             self.placeholderLabel
-                .sbu_constraint(equalTo: textView, leading: leading, top: 10)
+                .sbu_constraint(equalTo: textView, leading: leading, centerY: 0)
             self.setupTextViewHeight(textView: textView)
         }
         
@@ -690,28 +843,49 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         
         // Subviews in ContentHStackView
         self.leadingPaddingView
-            .sbu_constraint(width: self.leadingSpacing)
+            .sbu_constraint(width: self.leadingSpacingAdaptive)
         
         self.trailingPaddingView
-            .sbu_constraint(width: self.trailingSpacing)
+            .sbu_constraint(width: self.trailingSpacingAdaptive)
         
         // ContentVStackView
-        self.contentVStackView.sbu_constraint_equalTo(
-            leadingAnchor: self.safeAreaLayoutGuide.leadingAnchor,
-            leading: 0
-        )
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            self.contentVStackView.sbu_constraint_equalTo(
+                leadingAnchor: self.contentView.leadingAnchor,
+                leading: 16
+            )
+            self.contentVStackView.sbu_constraint_equalTo(
+                trailingAnchor: self.contentView.trailingAnchor,
+                trailing: -16
+            )
+        } else {
+            // TODO: `self.contentVStackView` should be constrained to `self.contentView`
+            self.contentVStackView.sbu_constraint_equalTo(
+                leadingAnchor: self.safeAreaLayoutGuide.leadingAnchor,
+                leading: 0
+            )
+            self.contentVStackView.sbu_constraint_equalTo(
+                trailingAnchor: self.safeAreaLayoutGuide.trailingAnchor,
+                trailing: 0
+            )
+        }
+        
         self.contentVStackView.sbu_constraint_equalTo(
             topAnchor: self.safeAreaLayoutGuide.topAnchor,
             top: layoutInsets.top
         )
         self.contentVStackView.sbu_constraint_equalTo(
-            trailingAnchor: self.safeAreaLayoutGuide.trailingAnchor,
-            trailing: 0
-        )
-        self.contentVStackView.sbu_constraint_equalTo(
-            bottomAnchor: self.safeAreaLayoutGuide.bottomAnchor,
+            bottomAnchor: SendbirdUI.config.common.shouldApplyLiquidGlass
+                ? self.bottomAnchor
+                : self.safeAreaLayoutGuide.bottomAnchor,
             bottom: layoutInsets.bottom
         )
+        
+        // glassView - constrain to fill baseStackView
+         if SendbirdUI.config.common.shouldApplyLiquidGlass {
+             self.glassEffectView?
+                 .sbu_constraint(equalTo: self.baseStackView, leading: 16, trailing: -16, top: 0, bottom: 0)
+         }
         
         // baseStackView
         self.baseStackView
@@ -725,10 +899,26 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     }
     
     /// This function handles the initialization of styles.
-    open override func setupStyles() {
+    open override func setupStyles() {  
         let theme = self.isOverlay ? self.overlayTheme : self.theme
         
-        self.backgroundColor = theme.backgroundColor
+        self.backgroundColor = theme.backgroundColorAdaptive
+        
+        // For liquid glass only (shadow + liquid glass effect)
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            // Shadow on baseStackView
+            self.baseStackView.layer.shadowColor = theme.inputViewShadowColor.cgColor
+            self.baseStackView.layer.shadowOffset = CGSize(width: 0, height: 2.18)
+            self.baseStackView.layer.shadowRadius = 10.91  // Figma blur 21.82 / 2
+            self.baseStackView.layer.shadowOpacity = 0.08
+
+            // Corner radius on glassEffectView
+            self.glassEffectView?.setupStyles(
+                cornerRadius: 22,
+                cornerCurve: .continuous,
+                clipsToBounds: true
+            )
+        }
         
         // placeholderLabel
         self.placeholderLabel.font = theme.textFieldPlaceholderFont
@@ -759,9 +949,9 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         }
         
         // textView
-        self.textView?.backgroundColor = theme.textFieldBackgroundColor
+        self.textView?.backgroundColor = theme.textFieldBackgroundColorAdaptive
+        self.textView?.layer.borderColor = theme.textFieldBorderColorAdaptive.cgColor
         self.textView?.tintColor = theme.textFieldTintColor
-        self.textView?.layer.borderColor = theme.textFieldBorderColor.cgColor
         self.textView?.typingAttributes = defaultAttributes
         
         // support rtl layout
@@ -774,18 +964,32 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         }
         
         // addButton
-        let iconAdd = SBUIconSetType.iconAdd
-            .image(with: (self.isFrozen || self.isMuted || self.isDisabledByServer || self.isDisabled)
-                   ? theme.buttonDisabledTintColor
-                   : theme.buttonTintColor,
-                   to: SBUIconSetType.Metric.defaultIconSize)
-        self.addButton?.setImage(iconAdd, for: .normal)
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            let iconPlus = SBUIconSetType.iconPlus
+                .image(with: (self.isFrozen || self.isMuted || self.isDisabledByServer || self.isDisabled)
+                       ? theme.buttonDisabledTintColor
+                       : theme.buttonTintColor,
+                       to: CGSize(value: SBUIconSetType.Metric.iconSizeLiquidGlass))
+                .sbu_addCircularBackgroundPadding(
+                    SBUIconSetType.Metric.iconPaddingLiquidGlass,
+                    color: UIColor(red: 0, green: 0, blue: 0, alpha: 0.03)
+                )
+            self.addButton?.setImage(iconPlus, for: .normal)
+        } else {
+            let iconAdd = SBUIconSetType.iconAdd
+                .image(with: (self.isFrozen || self.isMuted || self.isDisabledByServer || self.isDisabled)
+                       ? theme.buttonDisabledTintColor
+                       : theme.buttonTintColor,
+                       to: SBUIconSetType.Metric.defaultIconSizeAdaptive
+                )
+            self.addButton?.setImage(iconAdd, for: .normal)
+        }
         
         // IconSend
         self.sendButton?.setImage(
             SBUIconSetType.iconSend.image(
                 with: theme.buttonTintColor,
-                to: SBUIconSetType.Metric.defaultIconSize
+                to: SBUIconSetType.Metric.defaultIconSizeAdaptive
             ),
             for: .normal)
         
@@ -795,7 +999,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
                 with: (self.isFrozen || self.isMuted || self.isDisabledByServer || self.isDisabled)
                 ? theme.buttonDisabledTintColor
                 : theme.buttonTintColor,
-                to: SBUIconSetType.Metric.defaultIconSize
+                to: SBUIconSetType.Metric.defaultIconSizeAdaptive
             ),
             for: .normal)
         
@@ -823,7 +1027,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         )
         Self.cancelItem.color = theme.buttonTintColor
         
-        self.divider.backgroundColor = theme.channelViewDividerColor
+        self.divider.backgroundColor = theme.channelViewDividerColorAdaptive
     }
     
     public override func layoutSubviews() {
@@ -845,7 +1049,12 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         
         self.editView.isHidden = false
         self.editView.alpha = 1
-        
+
+        // Add extra top spacing in edit mode for liquid glass
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            self.inputViewTopSpacerHeightConstraint?.constant = 14
+        }
+
         self.updateTextViewHeight()
         let bottom = NSRange(location: (self.textView?.text.count ?? 0) - 1, length: 1)
         self.textView?.scrollRangeToVisible(bottom)
@@ -877,7 +1086,12 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         
         self.editView.isHidden = true
         self.editView.alpha = 0
-        
+
+        // Reset top spacing when exiting edit mode
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            self.inputViewTopSpacerHeightConstraint?.constant = 0
+        }
+
         self.updateTextViewHeight()
         
         self.layoutIfNeeded()
@@ -1005,7 +1219,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     /// - Since: 2.1.1
     public func setupTextViewHeight(textView: UIView) {
         self.textViewHeightConstraint?.isActive = false
-        self.textViewHeightConstraint = textView.heightAnchor.constraint(equalToConstant: self.textViewMinHeight)
+        self.textViewHeightConstraint = textView.heightAnchor.constraint(equalToConstant: self.textViewMinHeightAdaptive)
         self.textViewHeightConstraint?.isActive = true
     }
     
@@ -1016,8 +1230,8 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
         guard let textViewContentHeight = self.textView?.contentSize.height else { return }
         
         switch textViewContentHeight {
-        case ..<self.textViewMinHeight:
-            self.textViewHeightConstraint?.constant = self.textViewMinHeight
+        case ..<self.textViewMinHeightAdaptive:
+            self.textViewHeightConstraint?.constant = self.textViewMinHeightAdaptive
         case self.textViewMaxHeight...:
             self.textViewHeightConstraint?.constant = self.textViewMaxHeight
         default:

--- a/Sources/View/Channel/SBUBaseChannelViewController.Keyboard.swift
+++ b/Sources/View/Channel/SBUBaseChannelViewController.Keyboard.swift
@@ -105,7 +105,7 @@ extension SBUBaseChannelViewController {
             self.setKeyboardWindowFrame(origin: CGPoint(x: 0, y: 50))
             
             if let messageInputViewBottomConstraint = self.messageInputViewBottomConstraint {
-                messageInputViewBottomConstraint.constant = 0
+                messageInputViewBottomConstraint.constant = -SBUConstant.messageInputViewBottomSpacing
             }
         case false:
             // When the keyboard will show
@@ -137,12 +137,18 @@ extension SBUBaseChannelViewController {
             
             let keyboardHeight = getAdjustedKeyboardHeight(with: keyboardFrame.cgRectValue)
             let tabBarHeight = getTabBarHeight()
-            
-            self.messageInputViewBottomConstraint?.constant = -(keyboardHeight-tabBarHeight)
+
+            self.messageInputViewBottomConstraint?.constant = -(keyboardHeight-tabBarHeight+SBUConstant.messageInputViewKeyboardSpacing)
+
+            // For liquid glass mode: update content inset and scroll to bottom when keyboard shows
+            if SendbirdUI.config.common.shouldApplyLiquidGlass,
+               self.baseListComponent?.isScrollNearByBottom == true {
+                self.baseListComponent?.scrollTableView(to: 0)
+            }
         }
         self.view.layoutIfNeeded()
     }
-    
+
     @objc
     private func dismissKeyboardIfTouchInput(sender: UIPanGestureRecognizer) {
         guard let tableView = self.baseListComponent?.tableView else { return }
@@ -184,7 +190,7 @@ extension SBUBaseChannelViewController {
             // defense code to prevent bottom constant to be set as some other value
             self.messageInputViewBottomConstraint?.constant = self.isKeyboardShowing
             ? initialMessageInputBottomConstraint
-            : 0
+            : -SBUConstant.messageInputViewBottomSpacing
         default:
             break
         }

--- a/Sources/View/Channel/SBUBaseChannelViewController.swift
+++ b/Sources/View/Channel/SBUBaseChannelViewController.swift
@@ -228,6 +228,24 @@ open class SBUBaseChannelViewController: SBUBaseViewController, SBUBaseChannelVi
         NotificationCenter.default.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
     }
     
+    open override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updateListContentInsetForLiquidGlass()
+    }
+
+    func updateListContentInsetForLiquidGlass() {
+        guard SendbirdUI.config.common.shouldApplyLiquidGlass,
+              let inputComponent = self.baseInputComponent else { return }
+
+        let inputTopInView = inputComponent.frame.minY
+        let padding: CGFloat = 16
+        let bottomInset = self.view.frame.height - inputTopInView + padding
+        let topInset = self.view.safeAreaInsets.top
+
+        let insets = UIEdgeInsets(top: bottomInset, left: 0, bottom: topInset, right: 0)
+        baseListComponent?.updateTableViewContentInset(insets: insets)
+    }
+    
     /// Called when the application will resign activity.
     open func applicationWillResignActivity() { }
     
@@ -335,6 +353,7 @@ open class SBUBaseChannelViewController: SBUBaseViewController, SBUBaseChannelVi
     func setupStyles(theme: SBUChannelTheme) {
         self.setupNavigationBar(
             backgroundColor: self.theme.navigationBarTintColor,
+            gradientBackgroundTint: self.theme.navigationBarGradientTint,
             shadowColor: self.theme.navigationBarShadowColor
         )
         

--- a/Sources/View/Channel/SBUGroupChannelViewController.swift
+++ b/Sources/View/Channel/SBUGroupChannelViewController.swift
@@ -102,7 +102,7 @@ open class SBUGroupChannelViewController: SBUBaseChannelViewController, SBUGroup
     }
     
     // MARK: - Logic properties (Private)
-    
+
     // MARK: - Lifecycle
     
     /// If you have channel object, use this initialize function. And, if you have own message list params, please set it. If not set, it is used as the default value.
@@ -280,14 +280,29 @@ open class SBUGroupChannelViewController: SBUBaseChannelViewController, SBUGroup
             tableViewLeftConstraint?.isActive = false
             tableViewRightConstraint?.isActive = false
             
+            let topAnchor: NSLayoutAnchor<NSLayoutYAxisAnchor>
+            if SendbirdUI.config.common.shouldApplyLiquidGlass {
+                topAnchor = self.view.topAnchor
+            } else {
+                topAnchor = self.self.view.safeAreaLayoutGuide.topAnchor
+            }
+            
             self.tableViewTopConstraint = listComponent.topAnchor.constraint(
-                equalTo: self.view.safeAreaLayoutGuide.topAnchor,
+                equalTo: topAnchor,
                 constant: 0
             )
+            
+            let bottomAnchor: NSLayoutAnchor<NSLayoutYAxisAnchor>
+            if SendbirdUI.config.common.shouldApplyLiquidGlass {
+                bottomAnchor = self.view.bottomAnchor
+            } else {
+                bottomAnchor = self.inputComponent?.topAnchor ?? self.view.bottomAnchor
+            }
             self.tableViewBottomConstraint = listComponent.bottomAnchor.constraint(
-                equalTo: self.inputComponent?.topAnchor ?? self.view.bottomAnchor,
+                equalTo: bottomAnchor,
                 constant: 0
             )
+            
             self.tableViewLeftConstraint = listComponent.leftAnchor.constraint(
                 equalTo: self.view.leftAnchor, constant: 0
             )
@@ -299,8 +314,22 @@ open class SBUGroupChannelViewController: SBUBaseChannelViewController, SBUGroup
             tableViewBottomConstraint?.isActive = true
             tableViewLeftConstraint?.isActive = true
             tableViewRightConstraint?.isActive = true
+
+            // For liquid glass mode: position scrollBottomView above the input component
+            if SendbirdUI.config.common.shouldApplyLiquidGlass,
+               let scrollBottomView = listComponent.scrollBottomView {
+                if let inputComponent = self.inputComponent {
+                    scrollBottomView.translatesAutoresizingMaskIntoConstraints = false
+                    scrollBottomView.bottomAnchor.constraint(
+                        equalTo: inputComponent.topAnchor,
+                        constant: -8
+                    ).isActive = true
+                } else {
+                    scrollBottomView.sbu_constraint(equalTo: listComponent, bottom: 8)
+                }
+            }
         }
-        
+
         if let inputComponent = self.inputComponent {
             inputComponent.translatesAutoresizingMaskIntoConstraints = false
             
@@ -315,7 +344,7 @@ open class SBUGroupChannelViewController: SBUBaseChannelViewController, SBUGroup
             )
             self.messageInputViewBottomConstraint = inputComponent.bottomAnchor.constraint(
                 equalTo: self.view.bottomAnchor,
-                constant: 0
+                constant: -SBUConstant.messageInputViewBottomSpacing
             )
             self.messageInputViewLeftConstraint = inputComponent.leftAnchor.constraint(
                 equalTo: self.view.leftAnchor,
@@ -326,7 +355,9 @@ open class SBUGroupChannelViewController: SBUBaseChannelViewController, SBUGroup
                 constant: 0
             )
             
-            messageInputViewTopConstraint?.isActive = true
+            if !SendbirdUI.config.common.shouldApplyLiquidGlass {
+                messageInputViewTopConstraint?.isActive = true
+            }
             messageInputViewBottomConstraint?.isActive = true
             messageInputViewLeftConstraint?.isActive = true
             messageInputViewRightConstraint?.isActive = true
@@ -350,6 +381,9 @@ open class SBUGroupChannelViewController: SBUBaseChannelViewController, SBUGroup
     open override func updateStyles() {
         self.updateStyles(needsToLayout: true)
     }
+
+    // MARK: - Liquid Glass Layout Updates
+
 
     // MARK: - New message count
 
@@ -1360,9 +1394,9 @@ open class SBUGroupChannelViewController: SBUBaseChannelViewController, SBUGroup
     open override func baseChannelModule(_ listComponent: SBUBaseChannelModule.List, didScroll scrollView: UIScrollView) {
         guard let channel = self.channel else { return }
         super.baseChannelModule(listComponent, didScroll: scrollView)
-        
+
         self.lastSeenIndexPath = nil
-        
+
         if listComponent.isScrollNearByBottom {
             self.newMessagesCount = 0
             self.updateNewMessageInfo(hidden: true)

--- a/Sources/View/Channel/SBUOpenChannelViewController.swift
+++ b/Sources/View/Channel/SBUOpenChannelViewController.swift
@@ -422,10 +422,19 @@ open class SBUOpenChannelViewController: SBUBaseChannelViewController, SBUOpenCh
                 equalTo: self.headerComponent?.bottomAnchor ?? self.view.topAnchor,
                 constant: 0
             )
+            
+            // Liquid glass support
+            let bottomAnchor: NSLayoutAnchor<NSLayoutYAxisAnchor>
+            if SendbirdUI.config.common.shouldApplyLiquidGlass {
+                bottomAnchor = self.view.bottomAnchor
+            } else {
+                bottomAnchor = self.inputComponent?.topAnchor ?? self.view.bottomAnchor
+            }
             self.tableViewBottomConstraint = listComponent.bottomAnchor.constraint(
-                equalTo: self.inputComponent?.topAnchor ?? self.view.bottomAnchor,
+                equalTo: bottomAnchor,
                 constant: 0
             )
+            
             self.tableViewLeftConstraint = listComponent.leftAnchor.constraint(
                 equalTo: self.headerComponent?.leftAnchor ?? self.view.leftAnchor,
                 constant: 0
@@ -439,8 +448,19 @@ open class SBUOpenChannelViewController: SBUBaseChannelViewController, SBUOpenCh
             tableViewLeftConstraint?.isActive = true
             tableViewRightConstraint?.isActive = true
             tableViewBottomConstraint?.isActive = true
+
+            // For liquid glass mode: position scrollBottomView above the input component
+            if SendbirdUI.config.common.shouldApplyLiquidGlass,
+               let scrollBottomView = listComponent.scrollBottomView,
+               let inputComponent = self.inputComponent {
+                scrollBottomView.translatesAutoresizingMaskIntoConstraints = false
+                scrollBottomView.bottomAnchor.constraint(
+                    equalTo: inputComponent.topAnchor,
+                    constant: -8
+                ).isActive = true
+            }
         }
-        
+
         if let inputComponent = inputComponent {
             inputComponent
                 .sbu_constraint(equalTo: self.listComponent ?? self.view, left: 0, right: 0)
@@ -454,10 +474,12 @@ open class SBUOpenChannelViewController: SBUBaseChannelViewController, SBUOpenCh
             )
             self.messageInputViewBottomConstraint = self.inputComponent?.bottomAnchor.constraint(
                 equalTo: self.view.bottomAnchor,
-                constant: 0
+                constant: -SBUConstant.messageInputViewBottomSpacing
             )
             
-            self.messageInputViewTopConstraint?.isActive = true
+            if !SendbirdUI.config.common.shouldApplyLiquidGlass {
+                self.messageInputViewTopConstraint?.isActive = true
+            }
             self.messageInputViewBottomConstraint?.isActive = true
         }
     }
@@ -707,6 +729,7 @@ open class SBUOpenChannelViewController: SBUBaseChannelViewController, SBUOpenCh
     
     // MARK: - ScrollView
     public func configureOffset() {
+        if SendbirdUI.config.common.shouldApplyLiquidGlass { return }
         guard let tableView = self.listComponent?.tableView else { return }
         guard tableView.contentOffset.y < 0,
               let tableViewTopConstraint = self.tableViewTopConstraint,

--- a/Sources/View/ChannelList/SBUBaseChannelListViewController.swift
+++ b/Sources/View/ChannelList/SBUBaseChannelListViewController.swift
@@ -40,10 +40,21 @@ open class SBUBaseChannelListViewController: SBUBaseViewController {
     open override func setupViews() {
         self.navigationItem.titleView = self.baseHeaderComponent?.titleView
         self.navigationItem.leftBarButtonItem = self.baseHeaderComponent?.leftBarButton
-        self.navigationItem.rightBarButtonItem = self.baseHeaderComponent?.rightBarButton
-        
+
+        if let rightBarButton = self.baseHeaderComponent?.rightBarButton, !rightBarButton.isEmpty {
+            self.navigationItem.rightBarButtonItem = rightBarButton
+        } else {
+            self.navigationItem.rightBarButtonItem = nil
+        }
+
         self.navigationItem.leftBarButtonItems = self.baseHeaderComponent?.leftBarButtons
-        self.navigationItem.rightBarButtonItems = self.baseHeaderComponent?.rightBarButtons
+
+        if let rightBarButtons = self.baseHeaderComponent?.rightBarButtons,
+           !rightBarButtons.allSatisfy({ $0.isEmpty }) {
+            self.navigationItem.rightBarButtonItems = rightBarButtons
+        } else {
+            self.navigationItem.rightBarButtonItems = nil
+        }
         
         if let listComponent = self.baseListComponent {
             self.view.addSubview(listComponent)
@@ -51,13 +62,20 @@ open class SBUBaseChannelListViewController: SBUBaseViewController {
     }
     
     open override func setupLayouts() {
+        let useSafeArea: Bool
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            useSafeArea = false
+        } else {
+            useSafeArea = true
+        }
+        
         self.baseListComponent?.sbu_constraint(
             equalTo: self.view,
             left: 0,
             right: 0,
             top: 0,
             bottom: 0,
-            useSafeArea: true
+            useSafeArea: useSafeArea
         )
     }
     

--- a/Sources/View/ChannelList/SBUGroupChannelListViewController.swift
+++ b/Sources/View/ChannelList/SBUGroupChannelListViewController.swift
@@ -186,6 +186,7 @@ open class SBUGroupChannelListViewController: SBUBaseChannelListViewController, 
     open override func setupStyles() {
         self.setupNavigationBar(
             backgroundColor: self.theme.navigationBarTintColor,
+            gradientBackgroundTint: self.theme.navigationBarGradientTint,
             shadowColor: self.theme.navigationBarShadowColor
         )
         
@@ -363,6 +364,20 @@ open class SBUGroupChannelListViewController: SBUBaseChannelListViewController, 
         didTapRightItem rightItem: UIBarButtonItem
     ) {
         self.showCreateChannelOrTypeSelector()
+    }
+    
+    open func groupChannelListModule(
+        _ headerComponent: SBUBaseChannelListModule.Header,
+        didSelectCreateChannelType type: SBUCreateGroupChannelType
+    ) {
+        switch type {
+        case .group:
+            self.didSelectCreateGroupChannel()
+        case .superGroup:
+            self.didSelectCreateSuperGroupChannel()
+        case .broadcast:
+            self.didSelectCreateBroadcastChannel()
+        }
     }
     
     // MARK: - SBUGroupChannelListModuleListDelegate

--- a/Sources/View/ChannelList/SBUOpenChannelListViewController.swift
+++ b/Sources/View/ChannelList/SBUOpenChannelListViewController.swift
@@ -153,6 +153,7 @@ open class SBUOpenChannelListViewController: SBUBaseChannelListViewController, S
     open override func setupStyles() {
         self.setupNavigationBar(
             backgroundColor: self.theme.navigationBarTintColor,
+            gradientBackgroundTint: self.theme.navigationBarGradientTint,
             shadowColor: self.theme.navigationBarShadowColor
         )
         

--- a/Sources/View/Common/AlertView/SBUAlertView.swift
+++ b/Sources/View/Common/AlertView/SBUAlertView.swift
@@ -38,6 +38,7 @@ open class SBUAlertView: NSObject, SBUViewLifeCycle {
     public var parentView: UIView? = UIApplication.shared.currentWindow
     public private(set) var backgroundView = UIButton()
     public private(set) var containerView = UIView()
+    private var glassEffectView: UIVisualEffectView = UIVisualEffectView()
     public private(set) var titleLabel = UILabel()
     public private(set) var messageLabel: UILabel?
     public private(set) var inputField: UITextField?
@@ -53,7 +54,14 @@ open class SBUAlertView: NSObject, SBUViewLifeCycle {
     
     public private(set) var centerYRatio: CGFloat = 1.0
     
-    public var containerCornerRadius: CGFloat = 10.0
+    public var containerCornerRadius: CGFloat = 10.0 {
+        didSet {
+            self._containerCornerRadiusAdaptive = SBUAdaptive(base: containerCornerRadius, liquidGlass: containerCornerRadius)
+        }
+    }
+    
+    @SBUAdaptive(base: 10.0, liquidGlass: 34)
+    public var containerCornerRadiusAdaptive: CGFloat
     
     // MARK: Private properties
     /// Timer for countdown.
@@ -79,14 +87,22 @@ open class SBUAlertView: NSObject, SBUViewLifeCycle {
     private var dismissHandler: (() -> Void)?
     
     // TODO: static var?
-    let itemWidth: CGFloat = 270.0
+    let sideMarginLiquidGlass: CGFloat = 14.0
+
     let textInsideMargin: CGFloat = 3.0
     let textTopBottomMargin: CGFloat = 20.0
     let inputAreaHeight: CGFloat = 32.0
     let inputAreaMargin: CGFloat = 20.0
     let inputBottomMargin: CGFloat = 16
-    let buttonHeight: CGFloat = 44.0
-    let sideMargin: CGFloat = 16.0
+    
+    @SBUAdaptive(base: 270.0, liquidGlass: 300.0)
+    var itemWidth: CGFloat
+    
+    @SBUAdaptive(base: 16.0, liquidGlass: 14.0)
+    var sideMargin: CGFloat
+    
+    @SBUAdaptive(base: 44.0, liquidGlass: 48.0)
+    var buttonHeight: CGFloat
     
     var prevOrientation: UIDeviceOrientation = .unknown
     
@@ -206,7 +222,14 @@ open class SBUAlertView: NSObject, SBUViewLifeCycle {
             origin: .zero,
             size: CGSize(width: self.itemWidth, height: self.calculateTotalHeight())
         )
-        
+
+        // Create glass effect for Liquid Glass mode.
+        if SendbirdUI.config.common.shouldApplyLiquidGlass,
+           let glassView = createGlassEffectView() {
+            self.glassEffectView = glassView
+            containerView.insertSubview(self.glassEffectView, at: 0)
+        }
+
         // title
         self.titleLabel = self.createTitleLabel()
         self.containerView.addSubview(self.titleLabel)
@@ -236,28 +259,18 @@ open class SBUAlertView: NSObject, SBUViewLifeCycle {
         }
         
         // separator
-        self.separator = self.createSeparator(originY: originY)
-        self.containerView.addSubview(self.separator)
+        if SendbirdUI.config.common.shouldApplyLiquidGlass == false {
+            self.separator = self.createSeparator(originY: originY)
+            self.containerView.addSubview(self.separator)
+        }
 
         // Buttons
-        var buttonOriginX: CGFloat = 0.0
-        let buttonWidth = (cancelButtonItem == nil) ? itemWidth : itemWidth/2
-
-        if let cancelButton = self.createCancelButton(
-            originY: originY,
-            buttonOriginX: buttonOriginX
-        ) {
-            self.cancelButton = cancelButton
-            self.containerView.addSubview(cancelButton)
-            buttonOriginX += buttonWidth
-        }
-        
-        if let confirmButton = self.createConfirmButton(
-            originY: originY,
-            buttonOriginX: buttonOriginX
-        ) {
-            self.confirmButton = confirmButton
-            self.containerView.addSubview(confirmButton)
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            // Liquid glass: Buttons are stacked vertically
+            configureButtonsForLiquidGlass(originY: originY)
+        } else {
+            // Non-liquid glass: Buttons are placed side by side horizontally
+            configureButtonsForNonLiquidGlass(originY: originY)
         }
     }
     
@@ -272,11 +285,11 @@ open class SBUAlertView: NSObject, SBUViewLifeCycle {
     
     /// This function updates styles.
     open func updateStyles() {
-        self.backgroundView.backgroundColor = theme.overlayColor
-        self.containerView.backgroundColor = theme.backgroundColor
+        self.backgroundView.backgroundColor = theme.overlayColorAdaptive
+        self.containerView.backgroundColor = theme.backgroundColorAdaptive
         
         self.titleLabel.numberOfLines = 0
-        self.titleLabel.font = theme.alertTitleFont
+        self.titleLabel.font = theme.alertTitleFontAdaptive
         self.titleLabel.textColor = theme.alertTitleColor
         self.titleLabel.textAlignment = .center
         
@@ -299,13 +312,15 @@ open class SBUAlertView: NSObject, SBUViewLifeCycle {
         self.cancelButton?.titleLabel?.font = theme.alertButtonFont
         self.cancelButton?.titleLabel?.textColor = theme.alertButtonColor
         self.cancelButton?.setTitleColor(self.cancelButtonItem?.color ?? theme.alertButtonColor, for: .normal)
-        self.cancelButton?.setBackgroundImage(UIImage.from(color: theme.backgroundColor), for: .normal)
-        self.cancelButton?.setBackgroundImage(UIImage.from(color: theme.highlightedColor), for: .highlighted)
-        
+
         self.confirmButton.titleLabel?.font = theme.alertButtonFont
         self.confirmButton.setTitleColor(self.confirmButtonItem?.color ?? theme.alertButtonColor, for: .normal)
-        self.confirmButton.setBackgroundImage(UIImage.from(color: theme.backgroundColor), for: .normal)
-        self.confirmButton.setBackgroundImage(UIImage.from(color: theme.highlightedColor), for: .highlighted)
+
+        // button background color
+        self.cancelButton?.setBackgroundImage(UIImage.from(color: theme.alertButtonBackgroundColorAdaptive), for: .normal)
+        self.cancelButton?.setBackgroundImage(UIImage.from(color: theme.highlightedColorAdaptive), for: .highlighted)
+        self.confirmButton.setBackgroundImage(UIImage.from(color: theme.alertButtonBackgroundColorAdaptive), for: .normal)
+        self.confirmButton.setBackgroundImage(UIImage.from(color: theme.highlightedColorAdaptive), for: .highlighted)
     }
     
     /// This function handles the initialization of autolayouts.
@@ -318,7 +333,7 @@ open class SBUAlertView: NSObject, SBUViewLifeCycle {
 
         self.backgroundView.frame = parentView.bounds
         self.containerView.layer.masksToBounds = true
-        
+
         setRoundRectOnContainerView()
         
         // inputField: RoundRect
@@ -361,13 +376,13 @@ extension SBUAlertView {
     /// This function calculates the total height of the alert.
     public func calculateTotalHeight() -> CGFloat {
         var totalHeight: CGFloat = 0.0
-        
+
         totalHeight += self.titleHeight
 
         if self.message != nil {
             totalHeight += (self.textInsideMargin + self.messageHeight)
         }
-        
+
         if self.needInputField {
              // top, text-input, input, input-button
             totalHeight += (inputAreaMargin + inputAreaMargin + inputAreaHeight + inputBottomMargin)
@@ -375,9 +390,19 @@ extension SBUAlertView {
              // top, text-button
             totalHeight += (textTopBottomMargin + textTopBottomMargin)
         }
-        
+
         if confirmButtonItem != nil || cancelButtonItem != nil {
-            totalHeight += self.buttonHeight
+            if SendbirdUI.config.common.shouldApplyLiquidGlass {
+                // Liquid glass: Buttons are stacked vertically
+                let buttonCount = (cancelButtonItem != nil) ? 2 : 1
+                totalHeight += self.buttonHeight * CGFloat(buttonCount)
+                if cancelButtonItem != nil {
+                    totalHeight += 10 // spacing between buttons
+                }
+                totalHeight += self.sideMargin // bottom padding
+            } else {
+                totalHeight += self.buttonHeight
+            }
         }
         
         return totalHeight
@@ -405,7 +430,7 @@ extension SBUAlertView {
         self.getTextHeight(
             text: title,
             maxSize: CGSize(width: insideItemWidth, height: CGFloat.greatestFiniteMagnitude),
-            font: theme.alertTitleFont
+            font: theme.alertTitleFontAdaptive
         )
     }
     
@@ -424,8 +449,8 @@ extension SBUAlertView {
         setRoundRect(
             on: self.containerView,
             cornerRadii: CGSize(
-                width: containerCornerRadius,
-                height: containerCornerRadius
+                width: containerCornerRadiusAdaptive,
+                height: containerCornerRadiusAdaptive
             )
         )
     }
@@ -771,7 +796,8 @@ extension SBUAlertView {
         for subView in self.containerView.subviews {
             subView.removeFromSuperview()
         }
-        
+
+        self.glassEffectView.removeFromSuperview()
         self.inputField = UITextField()
         self.backgroundView.removeFromSuperview()
         self.containerView.removeFromSuperview()
@@ -831,6 +857,17 @@ extension SBUAlertView {
     }
     
     // MARK: Create items
+    private func createGlassEffectView() -> UIVisualEffectView? {
+        if let glassEffectView = SBULiquidGlassUtils.createGlassEffectView() {
+            glassEffectView.setupLayouts(
+                frame: containerView.bounds,
+                autoresizingMask: [.flexibleWidth, .flexibleHeight]
+            )
+            return glassEffectView
+        }
+        return nil
+    }
+    
     /// This function creates a title label.
     /// - Since: 3.28.0
     private func createTitleLabel() -> UILabel {
@@ -945,49 +982,113 @@ extension SBUAlertView {
     /// - Since: 3.28.0
     private func createCancelButton(
         originY: CGFloat,
-        buttonOriginX: CGFloat = 0.0
+        buttonOriginX: CGFloat = 0.0,
+        buttonWidth: CGFloat? = nil
     ) -> UIButton? {
-        let buttonWidth = (cancelButtonItem == nil) ? itemWidth : itemWidth/2
-        
-        if let cancelButtonItem = cancelButtonItem {
-            let cancelButton = UIButton(
-                frame: CGRect(
-                    origin: CGPoint(x: buttonOriginX, y: originY),
-                    size: CGSize(width: buttonWidth, height: buttonHeight)
-                )
+        guard let cancelButtonItem = cancelButtonItem else { return nil }
+
+        let width = buttonWidth ?? (itemWidth / 2)
+
+        let cancelButton = UIButton(
+            frame: CGRect(
+                origin: CGPoint(x: buttonOriginX, y: originY),
+                size: CGSize(width: width, height: buttonHeight)
             )
-            cancelButton.setTitle(cancelButtonItem.title, for: .normal)
-            cancelButton.addTarget(self, action: #selector(onClickAlertButton), for: .touchUpInside)
-            cancelButton.tag = 0
-            
+        )
+        cancelButton.setTitle(cancelButtonItem.title, for: .normal)
+        cancelButton.addTarget(self, action: #selector(onClickAlertButton), for: .touchUpInside)
+        cancelButton.tag = 0
+
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            cancelButton.layer.cornerRadius = 24
+            cancelButton.clipsToBounds = true
+        } else {
+            // Non-liquid glass: Add vertical separator line (horizontal layout)
             let separatorLine = UIView(frame: CGRect(
                 origin: CGPoint(x: cancelButton.bounds.maxX - 0.5, y: 0),
                 size: CGSize(width: 5, height: buttonHeight))
             )
             separatorLine.backgroundColor = theme.separatorColor
             cancelButton.addSubview(separatorLine)
-            
-            return cancelButton
         }
-        
-        return nil
+
+        return cancelButton
     }
     
     /// This function creates a confirm button.
     /// - Since: 3.28.0
     private func createConfirmButton(
         originY: CGFloat,
-        buttonOriginX: CGFloat = 0.0
+        buttonOriginX: CGFloat = 0.0,
+        buttonWidth: CGFloat? = nil
     ) -> UIButton? {
-        let buttonWidth = (cancelButtonItem == nil) ? itemWidth : itemWidth/2
+        let width = buttonWidth ?? ((cancelButtonItem == nil) ? itemWidth : itemWidth / 2)
         let confirmButton = UIButton(frame: CGRect(
             origin: CGPoint(x: buttonOriginX, y: originY),
-            size: CGSize(width: buttonWidth, height: buttonHeight))
+            size: CGSize(width: width, height: buttonHeight))
         )
         confirmButton.setTitle(confirmButtonItem?.title, for: .normal)
         confirmButton.addTarget(self, action: #selector(onClickAlertButton), for: .touchUpInside)
         confirmButton.tag = 1
+
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            confirmButton.layer.cornerRadius = 24
+            confirmButton.clipsToBounds = true
+        }
+
         return confirmButton
+    }
+    
+    /// - Since: 3.34.0
+    private func configureButtonsForNonLiquidGlass(originY: CGFloat) {
+        var buttonOriginX: CGFloat = 0.0
+        let buttonWidth = (cancelButtonItem == nil) ? itemWidth : itemWidth / 2
+
+        if let cancelButton = self.createCancelButton(
+            originY: originY,
+            buttonOriginX: buttonOriginX,
+            buttonWidth: buttonWidth
+        ) {
+            self.cancelButton = cancelButton
+            self.containerView.addSubview(cancelButton)
+            buttonOriginX += buttonWidth
+        }
+
+        if let confirmButton = self.createConfirmButton(
+            originY: originY,
+            buttonOriginX: buttonOriginX,
+            buttonWidth: buttonWidth
+        ) {
+            self.confirmButton = confirmButton
+            self.containerView.addSubview(confirmButton)
+        }
+    }
+    
+    /// - Since: 3.34.0
+    private func configureButtonsForLiquidGlass(originY: CGFloat) {
+        var originYcopied = originY
+        
+        let buttonWidth = self.insideItemWidth
+        let buttonOriginX = sideMargin // sideMarginLiquidGlass
+
+        if let confirmButton = self.createConfirmButton(
+            originY: originYcopied,
+            buttonOriginX: buttonOriginX,
+            buttonWidth: buttonWidth
+        ) {
+            self.confirmButton = confirmButton
+            self.containerView.addSubview(confirmButton)
+            originYcopied += buttonHeight + 10 // 10pt spacing between buttons
+        }
+
+        if let cancelButton = self.createCancelButton(
+            originY: originYcopied,
+            buttonOriginX: buttonOriginX,
+            buttonWidth: buttonWidth
+        ) {
+            self.cancelButton = cancelButton
+            self.containerView.addSubview(cancelButton)
+        }
     }
     
     // MARK: Orientation

--- a/Sources/View/Common/Menu/SBUMenuView.swift
+++ b/Sources/View/Common/Menu/SBUMenuView.swift
@@ -77,14 +77,34 @@ class SBUMenuView: NSObject {
     
     var window: UIWindow?
     var baseView = UIView()
+    var glassEffectView = UIVisualEffectView() // 3.34.0
     var backgroundView = UIButton()
     
-    let itemWidth: CGFloat = 180.0
+    @SBUAdaptive(base: 10.0, liquidGlass: 22.0)
+    var cornerRadius: CGFloat
+    
+    @SBUAdaptive(base: 180.0, liquidGlass: 198.0)
+    var itemWidth: CGFloat
+    
     let itemHeight: CGFloat = 40.0
-    let leftMargin: CGFloat = 14.0
-    let midMargin: CGFloat = 8.0
-    let rightMargin: CGFloat = 18.0
-    let topBottomMargin: CGFloat = 8.0
+    
+    @SBUAdaptive(base: 14.0, liquidGlass: 24.0)
+    var leftMargin: CGFloat
+    
+    @SBUAdaptive(base: 8.0, liquidGlass: 14.0)
+    var midMargin: CGFloat
+    
+    @SBUAdaptive(base: 18.0, liquidGlass: 24.0)
+    var rightMargin: CGFloat
+    
+    @SBUAdaptive(base: 8.0, liquidGlass: 10.0)
+    var imageTopBottomMargin: CGFloat
+    
+    @SBUAdaptive(base: 0.0, liquidGlass: 10.0)
+    var topBottomMargin: CGFloat
+    
+    @SBUAdaptive(base: 24.0, liquidGlass: 16.0)
+    var iconSize: CGFloat
     
     let bufferVerticalMargin: CGFloat = 15.0
     let bufferHorizontalMargin: CGFloat = 36.0
@@ -146,11 +166,12 @@ class SBUMenuView: NSObject {
         self.backgroundView.frame = self.window?.bounds ?? .zero
         self.backgroundView.backgroundColor = .clear
         self.backgroundView.addTarget(self, action: #selector(dismiss), for: .touchUpInside)
-        
-        let totalHeight = CGFloat(items.count) * itemHeight
+
+        let totalHeight = CGFloat(items.count) * itemHeight + (topBottomMargin * 2)
+        print("++ DEBUG: items.count=\(items.count), itemHeight=\(itemHeight), topBottomMargin=\(topBottomMargin), totalHeight=\(totalHeight)")
         var originY: CGFloat = 0.0
         var originX: CGFloat = 0.0
-        
+
         if point.y + totalHeight + bufferHorizontalMargin + itemHeight > window.frame.height {
             originY = window.frame.height - totalHeight - bufferHorizontalMargin - itemHeight
         } else if point.y < bufferHorizontalMargin {
@@ -166,17 +187,26 @@ class SBUMenuView: NSObject {
         } else {
             originX = point.x
         }
-        
+
         self.baseView.frame = CGRect(
             origin: CGPoint(x: originX, y: originY),
             size: CGSize(width: self.itemWidth, height: totalHeight)
         )
+
+        // Liquid glass
+        if SendbirdUI.config.common.shouldApplyLiquidGlass,
+            let visualEffectView = createGlassEffectView() {
+            self.glassEffectView = visualEffectView
+            self.baseView.insertSubview(self.glassEffectView, at: 0)
+        }
         
-        var itemOriginY: CGFloat = 0.0
+        let showSeparator = !SendbirdUI.config.common.shouldApplyLiquidGlass
+
+        var itemOriginY: CGFloat = topBottomMargin
         for index in 0..<items.count {
             let button = self.makeItems(
                 item: items[index],
-                separator: (index != items.count-1),
+                separator: showSeparator && (index != items.count-1),
                 isTop: (index == 0),
                 isBottom: (index == items.count-1),
                 theme: oneTimetheme ?? self.theme
@@ -185,7 +215,7 @@ class SBUMenuView: NSObject {
             var buttonFrame = button.frame
             buttonFrame.origin = CGPoint(x: 0, y: itemOriginY)
             button.frame = buttonFrame
-            button.backgroundColor = oneTimetheme?.backgroundColor ?? theme.backgroundColor
+            button.backgroundColor = oneTimetheme?.backgroundColorAdaptive ?? theme.backgroundColorAdaptive
             
             self.baseView.addSubview(button)
             
@@ -196,8 +226,8 @@ class SBUMenuView: NSObject {
 
         window.addSubview(self.backgroundView)
         window.addSubview(self.baseView)
-        
         self.baseView.alpha = 0.0
+        
         self.isShowing = true
         UIView.animate(withDuration: 0.2, animations: {
             self.baseView.alpha = 1.0
@@ -237,18 +267,16 @@ class SBUMenuView: NSObject {
         isBottom: Bool,
         theme: SBUComponentTheme
     ) -> UIButton {
-        
         let itemButton = UIButton(
             frame: CGRect(
                 origin: .zero,
-                size: CGSize(width: self.itemWidth, height: self.itemHeight)
+                size: CGSize(width: itemWidth, height: self.itemHeight)
             )
         )
-        
-        itemButton.setBackgroundImage(UIImage.from(color: theme.backgroundColor), for: .normal)
+
+        itemButton.setBackgroundImage(UIImage.from(color: theme.backgroundColorAdaptive), for: .normal)
         itemButton.setBackgroundImage(UIImage.from(color: theme.highlightedColor), for: .highlighted)
         itemButton.addTarget(self, action: #selector(onClickMenuButton), for: .touchUpInside)
-        let imageSize: CGFloat = 24.0
         
         let titleLabel = UILabel()
         
@@ -267,12 +295,23 @@ class SBUMenuView: NSObject {
         var titleLabelPosX: CGFloat = 0
         var titleLabelWidth: CGFloat = 0
         var textAlignment: NSTextAlignment = .left
-        if UIView.getCurrentLayoutDirection().isLTR == true {
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            // Liquid glass: Image on LEFT, Title on RIGHT
+            textAlignment = .left
+            imageViewPosX = leftMargin
+            if item.image != nil {
+                titleLabelPosX = leftMargin + iconSize + midMargin
+                titleLabelWidth = itemWidth - leftMargin - iconSize - midMargin - rightMargin
+            } else {
+                titleLabelPosX = leftMargin
+                titleLabelWidth = itemWidth - leftMargin - rightMargin
+            }
+        } else if UIView.getCurrentLayoutDirection().isLTR == true {
             textAlignment = .left
             titleLabelPosX = leftMargin
             if item.image != nil {
-                imageViewPosX = itemWidth - rightMargin - imageSize
-                titleLabelWidth = itemWidth - leftMargin - midMargin - imageSize - rightMargin
+                imageViewPosX = itemWidth - rightMargin - iconSize
+                titleLabelWidth = itemWidth - leftMargin - midMargin - iconSize - rightMargin
             } else {
                 titleLabelWidth = itemWidth - leftMargin - rightMargin
             }
@@ -280,11 +319,11 @@ class SBUMenuView: NSObject {
             textAlignment = .right
             imageViewPosX = leftMargin
             if item.image != nil {
-                titleLabelPosX = leftMargin + imageSize + midMargin
-                titleLabelWidth = itemWidth - leftMargin - imageSize - midMargin - rightMargin
+                titleLabelPosX = leftMargin + iconSize + midMargin
+                titleLabelWidth = itemWidth - leftMargin - iconSize - midMargin - rightMargin
             } else {
                 titleLabelPosX = leftMargin
-                titleLabelWidth = itemWidth - leftMargin - rightMargin
+                titleLabelWidth = itemWidth - leftMargin - midMargin
             }
         }
         
@@ -300,10 +339,10 @@ class SBUMenuView: NSObject {
         let imageView = UIImageView()
         if let image = item.image {
             imageView.frame = CGRect(
-                origin: CGPoint(x: imageViewPosX, y: topBottomMargin),
-                size: CGSize(width: imageSize, height: imageSize)
+                origin: CGPoint(x: imageViewPosX, y: imageTopBottomMargin),
+                size: CGSize(width: iconSize, height: iconSize)
             )
-            
+
             imageView.image = image
         }
         
@@ -341,7 +380,7 @@ class SBUMenuView: NSObject {
         rectShape.path = UIBezierPath(
             roundedRect: itemButton.bounds,
             byRoundingCorners: optionSet,
-            cornerRadii: CGSize(width: 10, height: 10)
+            cornerRadii: CGSize(width: cornerRadius, height: cornerRadius)
         ).cgPath
         itemButton.layer.mask = rectShape
         return itemButton
@@ -353,11 +392,30 @@ class SBUMenuView: NSObject {
             roundedRect: self.baseView.bounds,
             cornerRadius: self.baseView.layer.cornerRadius
         ).cgPath
-        self.baseView.layer.shadowColor = theme.shadowColor.withAlphaComponent(0.5).cgColor
+        self.baseView.layer.shadowColor = theme.shadowColorAdaptive.cgColor
         self.baseView.layer.shadowOffset = CGSize(width: 5, height: 5)
         self.baseView.layer.shadowOpacity = 0.5
         self.baseView.layer.shadowRadius = 5
         self.baseView.layer.masksToBounds = false
+    }
+    
+    /// - Since: 3.34.0
+    private func createGlassEffectView() -> UIVisualEffectView? {
+        if let glassEffectView = SBULiquidGlassUtils.createGlassEffectView() {
+            glassEffectView.setupLayouts(
+                frame: baseView.bounds,
+                autoresizingMask: [.flexibleWidth, .flexibleHeight]
+            )
+            
+            glassEffectView.setupStyles(
+                cornerRadius: cornerRadius,
+                cornerCurve: nil,
+                clipsToBounds: true
+            )
+            
+            return glassEffectView
+        }
+        return nil
     }
     
     // MARK: Button action

--- a/Sources/View/Common/SBUBarButtonItem.swift
+++ b/Sources/View/Common/SBUBarButtonItem.swift
@@ -13,10 +13,12 @@ import UIKit
 open class SBUBarButtonItem: UIBarButtonItem {
     required public init?(coder: NSCoder) {
         super.init(coder: coder)
+        self.disableLiquidGlassIfNeeded()
     }
-    
+
     required public override init() {
         super.init()
+        self.disableLiquidGlassIfNeeded()
     }
 
     static func backButton(target: Any, selector: Selector) -> UIBarButtonItem {
@@ -35,5 +37,26 @@ open class SBUBarButtonItem: UIBarButtonItem {
             target: target,
             action: selector
         )
+    }
+}
+
+extension UIBarButtonItem {
+    /// Hides the shared liquid glass background when liquid glass is disabled.
+    /// - Since: 3.34.0
+    func disableLiquidGlassIfNeeded() {
+        guard !SendbirdUI.config.common.shouldApplyLiquidGlass else { return }
+        #if compiler(>=6.2)
+        if #available(iOS 26.0, *) {
+            self.hidesSharedBackground = true
+        }
+        #endif
+    }
+}
+
+extension Array where Element == UIBarButtonItem {
+    /// Hides the shared liquid glass background on all items when liquid glass is disabled.
+    /// - Since: 3.34.0
+    func disableLiquidGlassIfNeeded() {
+        self.forEach { $0.disableLiquidGlassIfNeeded() }
     }
 }

--- a/Sources/View/SBUBaseViewController.swift
+++ b/Sources/View/SBUBaseViewController.swift
@@ -50,6 +50,20 @@ open class SBUBaseViewController: UIViewController, UINavigationControllerDelega
     /// Used to check if navigation bar update is needed.
     /// - Since: 3.33.1
     var previousNavBarShadowColor = UIColor()
+    /// Caches previous liquid glass navigation bar background tint color.
+    /// Used to check if navigation bar update is needed.
+    /// - Since: 3.34.0
+    var previousLiquidGlassNavBarBackgroundTint = UIColor()
+
+    /// Container view for the liquid glass navigation bar gradient.
+    /// Stored to prevent creating multiple views on repeated calls.
+    /// - Since: 3.34.0
+    var liquidGlassGradientContainerView: UIView?
+
+    /// Gradient layer for the liquid glass navigation bar.
+    /// Stored to allow updating colors without recreating the layer.
+    /// - Since: 3.34.0
+    var liquidGlassGradientLayer: CAGradientLayer?
     
     // MARK: - Lifecycle
     open override func loadView() {
@@ -109,18 +123,60 @@ open class SBUBaseViewController: UIViewController, UINavigationControllerDelega
     
     /// This function updates styles with boolean parameter value that represents whether layout or not
     open func updateStyles(needsToLayout: Bool) { }
+
+    /// Checks if non-liquid glass navigation bar update is needed.
+    /// - Since: 3.34.0
+    func shouldUpdateNonLiquidGlassNavigationBar(
+        backgroundColor: UIColor,
+        shadowColor: UIColor
+    ) -> Bool {
+        backgroundColor != previousNavBarBackgroundColor || shadowColor != previousNavBarShadowColor
+    }
+    
+    /// Checks if liquid glass navigation bar update is needed.
+    /// - Since: 3.34.0
+    func shouldUpdateLiquidGlassNavigationBar(gradientBackgroundTint: UIColor) -> Bool {
+        gradientBackgroundTint != previousLiquidGlassNavBarBackgroundTint
+    }
     
     /// This function setups navigationBar's background color and shadow color.
     /// - Parameters:
     ///   - backgroundColor: background color
     ///   - shadowColor: shadow color
     open func setupNavigationBar(backgroundColor: UIColor, shadowColor: UIColor) {
+        self.setupNavigationBar(
+            backgroundColor: backgroundColor,
+            gradientBackgroundTint: backgroundColor,
+            shadowColor: shadowColor
+        )
+    }
+    
+    open func setupNavigationBar(
+        backgroundColor: UIColor,
+        gradientBackgroundTint: UIColor,
+        shadowColor: UIColor
+    ) {
         if let navigationController = self.navigationController {
             self.prevNavigationBarSettings?.save(with: navigationController)
         }
+
+        if SendbirdUI.config.common.shouldApplyLiquidGlass {
+            guard self.shouldUpdateLiquidGlassNavigationBar(
+                gradientBackgroundTint: gradientBackgroundTint
+            ) else { return }
+            
+            #if compiler(>=6.2)
+            if #available(iOS 26.0, *) {
+                // update
+                self.previousLiquidGlassNavBarBackgroundTint = gradientBackgroundTint
+                
+                self.setupLiquidGlassNavigationBar(gradientBackgroundTint: gradientBackgroundTint)
+            }
+            #endif
+            return
+        }
         
-        // Check if navigation bar update is needed.
-        guard self.shouldUpdateNavigationBar(
+        guard self.shouldUpdateNonLiquidGlassNavigationBar(
             backgroundColor: backgroundColor,
             shadowColor: shadowColor
         ) else { return }
@@ -128,7 +184,7 @@ open class SBUBaseViewController: UIViewController, UINavigationControllerDelega
         // update
         self.previousNavBarBackgroundColor = backgroundColor
         self.previousNavBarShadowColor = shadowColor
-
+        
         self.navigationController?.navigationBar.setBackgroundImage(
             UIImage.from(color: backgroundColor),
             for: .default
@@ -136,7 +192,7 @@ open class SBUBaseViewController: UIViewController, UINavigationControllerDelega
         self.navigationController?.navigationBar.shadowImage = UIImage.from(
             color: shadowColor
         )
-        
+
         // For iOS 13
         self.navigationController?.sbu_setupNavigationBarAppearance(
             tintColor: backgroundColor,
@@ -215,6 +271,58 @@ open class SBUBaseViewController: UIViewController, UINavigationControllerDelega
                 SBULoading.stop()
             }
         }
+    }
+    
+    // MARK: - Liquid Glass (iOS 26+)
+    
+    @available(iOS 26.0, *)
+    open func setupLiquidGlassNavigationBar(gradientBackgroundTint: UIColor) {
+        SBULog.info("gradientBackgroundTint: \(gradientBackgroundTint)")
+
+        // If container view already exists, just update the gradient colors
+        if let gradientLayer = self.liquidGlassGradientLayer {
+            gradientLayer.colors = [
+                gradientBackgroundTint.withAlphaComponent(1.0).cgColor,
+                gradientBackgroundTint.withAlphaComponent(0.0).cgColor
+            ]
+            return
+        }
+
+        // Create container view
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+
+        // Add to view hierarchy
+        self.view.addSubview(containerView)
+
+        // Setup constraints - height 110, full width, at screen top (ignoring safe area)
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            containerView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            containerView.heightAnchor.constraint(equalToConstant: 110)
+        ])
+
+        // Create gradient layer
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.colors = [
+            gradientBackgroundTint.withAlphaComponent(1.0).cgColor,
+            gradientBackgroundTint.withAlphaComponent(0.0).cgColor
+        ]
+        gradientLayer.locations = [0.0, 1.0]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
+
+        // Add gradient to container
+        containerView.layer.addSublayer(gradientLayer)
+
+        // Set gradient frame after layout
+        containerView.layoutIfNeeded()
+        gradientLayer.frame = containerView.bounds
+
+        // Store references for reuse
+        self.liquidGlassGradientContainerView = containerView
+        self.liquidGlassGradientLayer = gradientLayer
     }
     
     func showBusyServerCountdownAlert(retryAfter: UInt) {


### PR DESCRIPTION
# SendbirdUIKit

## New Feature
### Liquid Glass Support (iOS 26+)

SendbirdUIKit now supports Apple's Liquid Glass design introduced in iOS 26. When running on iOS 26+, liquid glass styling is applied automatically across navigation bars, message input views, alert views, menus, and channel list headers.

**Opting Out**

Liquid glass is enabled by default on iOS 26+. To disable it and use the classic appearance:
```swift
  SendbirdUI.config.common.isLiquidGlassEnabled = false
```

**What's Affected**
The below components have been updated to support liquid glass styling:
- Navigation bars
- Message input view
- Alert views
- Menu views (for when long-pressing messages)
- "Create channel" context menu in GroupChannelList Header